### PR TITLE
class-validator-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   },
   "resolutions": {
     "ansi-regex": "^5.0.1",
+    "class-transformer": "0.4.0",
+    "class-validator": "0.13.1",
     "minimist": "^1.2.6",
     "@xmldom/xmldom": "0.7.7"
   },
@@ -45,7 +47,7 @@
     "axios": "^0.27.2",
     "cheerio": "^1.0.0-rc.11",
     "class-transformer": "0.4.0",
-    "class-validator": "^0.14.0",
+    "class-validator": "0.13.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "fs": "^0.0.1-security",


### PR DESCRIPTION
rolling class-validator back to 0.13.1 since 0.14.0 breaks things