### PR TITLE
5416 - Required fields for GET EM Submsission Access

### DIFF
--- a/src/dto/em-submission-access.params.dto.ts
+++ b/src/dto/em-submission-access.params.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsOptional,
   ValidationArguments,
-  IsEnum,
+  IsEnum, IsNotEmpty,
 } from 'class-validator';
 
 import { Status } from '../enums/status.enum';
@@ -13,8 +13,8 @@ import { MonitorPlan } from '../entities/monitor-plan.entity';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 
 export class EmSubmissionAccessParamsDTO {
-  @IsOptional()
   @ApiProperty()
+  @IsNotEmpty({message: (args: ValidationArguments) => `${args.property} is required`})
   @IsValidCode(Plant, {
     message: (args: ValidationArguments) => {
       return `The ${args.property} is not valid. Refer to the list of available facilityRecordIds for valid values '/facilities-mgmt/facilities'`;
@@ -23,8 +23,8 @@ export class EmSubmissionAccessParamsDTO {
   @Type(() => Number)
   orisCode?: number;
 
-  @IsOptional()
   @ApiProperty()
+  @IsNotEmpty({message: (args: ValidationArguments) => `${args.property} is required`})
   @IsValidCode(MonitorPlan, {
     message: (args: ValidationArguments) => {
       return `The reported ${args.property} is invalid.`;


### PR DESCRIPTION
Makes orisCode and monitorPlanId required to filter Emmision Submission Access (GET /camd-services/admin/em-submission-access)