### PR TITLE
Feature/5515 QA Data Maintenance: Modify QA DB Table

### DIFF
--- a/src/dto/qa-update.dto.ts
+++ b/src/dto/qa-update.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class QaUpdateDto {
+  @ApiProperty()
+  @IsString()
+  resubExplanation: string;
+}

--- a/src/entities/qa-cert-event-maint-vw.entity.ts
+++ b/src/entities/qa-cert-event-maint-vw.entity.ts
@@ -88,4 +88,7 @@ export class QaCertEventMaintView extends BaseEntity {
     name: 'severity_description',
   })
   severityDescription: string;
+
+  @ViewColumn({ name: 'resub_explanation' })
+  resubExplanation: string;
 }

--- a/src/entities/qa-cert-event.entity.ts
+++ b/src/entities/qa-cert-event.entity.ts
@@ -88,4 +88,7 @@ export class QaCertEvent extends BaseEntity {
 
   @Column({ name: 'eval_status_cd' })
   evalStatusCode: string;
+
+  @Column({ name: 'resub_explanation' })
+  resubExplanation: string;
 }

--- a/src/entities/qa-supp.entity.ts
+++ b/src/entities/qa-supp.entity.ts
@@ -10,4 +10,7 @@ export class QaSuppData extends BaseEntity {
 
   @Column({ name: 'submission_availability_cd' })
   submissionAvailabilityCode: string;
+
+  @Column({ name: 'resub_explanation' })
+  resubExplanation: string;
 }

--- a/src/entities/qa-tee-maint-vw.entity.ts
+++ b/src/entities/qa-tee-maint-vw.entity.ts
@@ -80,8 +80,12 @@ export class QaTeeMaintView extends BaseEntity {
     name: 'severity_cd',
   })
   severityCode: string;
+
   @ViewColumn({
     name: 'severity_description',
   })
   severityDescription: string;
+
+  @ViewColumn({ name: 'resub_explanation' })
+  resubExplanation: string;
 }

--- a/src/entities/qa-tee.entity.ts
+++ b/src/entities/qa-tee.entity.ts
@@ -75,4 +75,7 @@ export class QaTee extends BaseEntity {
 
   @Column({ name: 'eval_status_cd' })
   evalStatusCode: string;
+
+  @Column({ name: 'resub_explanation' })
+  resubExplanation: string;
 }

--- a/src/entities/qa-test-summary-maint-vw.entity.ts
+++ b/src/entities/qa-test-summary-maint-vw.entity.ts
@@ -80,32 +80,42 @@ export class QaTestSummaryMaintView extends BaseEntity {
     name: 'end_date_time',
   })
   endDateTime: string;
+
   @ViewColumn({
     name: 'test_comment',
   })
   testComment: string;
+
   @ViewColumn({
     name: 'span_scale_cd',
   })
   spanScaleCode: string;
+
   @ViewColumn({
     name: 'injection_protocol_cd',
   })
   injectionProtocolCode: string;
+
   @ViewColumn({
     name: 'submission_availability_cd',
   })
   submissionAvailabilityCode: string;
+
   @ViewColumn({
     name: 'submission_availability_description',
   })
   submissionAvailabilityDescription: string;
+
   @ViewColumn({
     name: 'severity_cd',
   })
   severityCode: string;
+
   @ViewColumn({
     name: 'severity_description',
   })
   severityDescription: string;
+
+  @ViewColumn({ name: 'resub_explanation' })
+  resubExplanation: string;
 }

--- a/src/qa-cert-event/qa-cert-event.controller.spec.ts
+++ b/src/qa-cert-event/qa-cert-event.controller.spec.ts
@@ -8,10 +8,12 @@ import { QaCertMaintParamsDto } from '../dto/qa-cert-maint-params.dto';
 import { EntityManager } from 'typeorm';
 import { QaCertEventMaintView } from '../entities/qa-cert-event-maint-vw.entity';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 describe('QaCertEventController', () => {
   let controller: QaCertEventController;
   let service: QaCertEventService;
+  let updatePayload;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +24,7 @@ describe('QaCertEventController', () => {
 
     controller = module.get<QaCertEventController>(QaCertEventController);
     service = module.get<QaCertEventService>(QaCertEventService);
+    updatePayload = new QaUpdateDto();
   });
 
   it('should be defined', () => {
@@ -48,7 +51,9 @@ describe('QaCertEventController', () => {
     };
     jest.spyOn(service, 'updateSubmissionStatus').mockResolvedValue(record);
 
-    expect(await controller.updateSubmissionStatus('id', user)).toEqual(record);
+    expect(
+      await controller.updateSubmissionStatus('id', user, updatePayload),
+    ).toEqual(record);
   });
 
   it('should return data for deleteQACertEventData controller method', async () => {

--- a/src/qa-cert-event/qa-cert-event.controller.ts
+++ b/src/qa-cert-event/qa-cert-event.controller.ts
@@ -1,5 +1,12 @@
 import { Controller, UseGuards } from '@nestjs/common';
-import { Get, Put, Delete, Query, Param } from '@nestjs/common/decorators';
+import {
+  Get,
+  Put,
+  Delete,
+  Query,
+  Param,
+  Body,
+} from '@nestjs/common/decorators';
 import {
   ApiBearerAuth,
   ApiOkResponse,
@@ -17,6 +24,7 @@ import { QaCertMaintParamsDto } from '../dto/qa-cert-maint-params.dto';
 import { QaCertEventMaintView } from '../entities/qa-cert-event-maint-vw.entity';
 import { User } from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -54,8 +62,9 @@ export class QaCertEventController {
   updateSubmissionStatus(
     @Param('id') id: string,
     @User() user: CurrentUser,
+    @Body() payload: QaUpdateDto,
   ): Promise<QaCertEventMaintView> {
-    return this.service.updateSubmissionStatus(id, user.userId);
+    return this.service.updateSubmissionStatus(id, user.userId, payload);
   }
 
   @Delete(':id')

--- a/src/qa-cert-event/qa-cert-event.service.spec.ts
+++ b/src/qa-cert-event/qa-cert-event.service.spec.ts
@@ -2,10 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { QaCertEventService } from './qa-cert-event.service';
 import { EntityManager } from 'typeorm';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 describe('QaCertEventService', () => {
   let service: QaCertEventService;
   let entityManager: EntityManager;
+  let updatePayload;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,6 +17,7 @@ describe('QaCertEventService', () => {
     service = module.get<QaCertEventService>(QaCertEventService);
 
     entityManager = module.get<EntityManager>(EntityManager);
+    updatePayload = new QaUpdateDto();
   });
 
   it('should be defined', () => {
@@ -32,7 +35,11 @@ describe('QaCertEventService', () => {
     jest.spyOn(entityManager, 'query').mockResolvedValue([[], 1]);
     jest.spyOn(entityManager, 'findOne').mockResolvedValue({});
 
-    const result = await service.updateSubmissionStatus('id', 'userId');
+    const result = await service.updateSubmissionStatus(
+      'id',
+      'userId',
+      updatePayload,
+    );
     expect(result).toEqual({});
   });
 
@@ -45,7 +52,7 @@ describe('QaCertEventService', () => {
 
     let errored = false;
     try {
-      await service.updateSubmissionStatus('id', 'userId');
+      await service.updateSubmissionStatus('id', 'userId', updatePayload);
     } catch {
       errored = true;
     }

--- a/src/qa-cert-event/qa-cert-event.service.ts
+++ b/src/qa-cert-event/qa-cert-event.service.ts
@@ -4,6 +4,7 @@ import { EntityManager } from 'typeorm';
 import { QaCertEventMaintView } from '../entities/qa-cert-event-maint-vw.entity';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 @Injectable()
 export class QaCertEventService {
   constructor(
@@ -30,6 +31,7 @@ export class QaCertEventService {
   async updateSubmissionStatus(
     id: string,
     userId: string,
+    payload: QaUpdateDto,
   ): Promise<QaCertEventMaintView> {
     let recordToUpdate: QaCertEventMaintView;
 
@@ -39,9 +41,10 @@ export class QaCertEventService {
         `UPDATE camdecmps.qa_cert_event 
       SET submission_availability_cd = $2,
       userid = $3,
-      update_date = $4
+      update_date = $4,
+      resub_explanation = $5
       WHERE qa_cert_event_id = $1`,
-        [id, 'REQUIRE', userId, currentDateTime()],
+        [id, 'REQUIRE', userId, currentDateTime(), payload?.resubExplanation],
       );
       recordToUpdate = await this.manager.findOne(QaCertEventMaintView, id);
       if (!recordToUpdate)

--- a/src/qa-test-extension-exemption/qa-test-extension-exemption.controller.spec.ts
+++ b/src/qa-test-extension-exemption/qa-test-extension-exemption.controller.spec.ts
@@ -8,10 +8,12 @@ import { QaCertMaintParamsDto } from '../dto/qa-cert-maint-params.dto';
 import { EntityManager } from 'typeorm';
 import { QaTeeMaintView } from '../entities/qa-tee-maint-vw.entity';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 describe('QaTestExtensionExemptionController', () => {
   let controller: QaTestExtensionExemptionController;
   let service: QaTestExtensionExemptionService;
+  let updatePayload;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -31,6 +33,8 @@ describe('QaTestExtensionExemptionController', () => {
     service = module.get<QaTestExtensionExemptionService>(
       QaTestExtensionExemptionService,
     );
+
+    updatePayload = new QaUpdateDto();
   });
 
   it('should be defined', () => {
@@ -57,7 +61,9 @@ describe('QaTestExtensionExemptionController', () => {
     };
     jest.spyOn(service, 'updateSubmissionStatus').mockResolvedValue(record);
 
-    expect(await controller.updateSubmissionStatus('id', user)).toEqual(record);
+    expect(
+      await controller.updateSubmissionStatus('id', user, updatePayload),
+    ).toEqual(record);
   });
 
   it('should return data for deleteQACertTeeData controller method', async () => {

--- a/src/qa-test-extension-exemption/qa-test-extension-exemption.controller.ts
+++ b/src/qa-test-extension-exemption/qa-test-extension-exemption.controller.ts
@@ -1,5 +1,12 @@
 import { Controller, UseGuards } from '@nestjs/common';
-import { Get, Put, Delete, Query, Param } from '@nestjs/common/decorators';
+import {
+  Get,
+  Put,
+  Delete,
+  Query,
+  Param,
+  Body,
+} from '@nestjs/common/decorators';
 import {
   ApiBearerAuth,
   ApiOkResponse,
@@ -17,6 +24,7 @@ import { QaCertMaintParamsDto } from '../dto/qa-cert-maint-params.dto';
 import { QaTeeMaintView } from '../entities/qa-tee-maint-vw.entity';
 import { User } from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 @Controller()
 @ApiSecurity('APIKey')
 @ApiTags('QA Test Extension Exemption Maintenance')
@@ -50,8 +58,9 @@ export class QaTestExtensionExemptionController {
   updateSubmissionStatus(
     @Param('id') id: string,
     @User() user: CurrentUser,
+    @Body() payload: QaUpdateDto,
   ): Promise<QaTeeMaintView> {
-    return this.service.updateSubmissionStatus(id, user.userId);
+    return this.service.updateSubmissionStatus(id, user.userId, payload);
   }
 
   @Delete(':id')

--- a/src/qa-test-extension-exemption/qa-test-extension-exemption.service.spec.ts
+++ b/src/qa-test-extension-exemption/qa-test-extension-exemption.service.spec.ts
@@ -2,10 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { QaTestExtensionExemptionService } from './qa-test-extension-exemption.service';
 import { EntityManager } from 'typeorm';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 describe('QaTestExtensionExemptionService', () => {
   let service: QaTestExtensionExemptionService;
   let entityManager: EntityManager;
+  let updatePayload;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -16,6 +18,7 @@ describe('QaTestExtensionExemptionService', () => {
       QaTestExtensionExemptionService,
     );
     entityManager = module.get<EntityManager>(EntityManager);
+    updatePayload = new QaUpdateDto();
   });
 
   it('should be defined', () => {
@@ -33,7 +36,11 @@ describe('QaTestExtensionExemptionService', () => {
     jest.spyOn(entityManager, 'query').mockResolvedValue([[], 1]);
     jest.spyOn(entityManager, 'findOne').mockResolvedValue({});
 
-    const result = await service.updateSubmissionStatus('id', 'userId');
+    const result = await service.updateSubmissionStatus(
+      'id',
+      'userId',
+      updatePayload,
+    );
     expect(result).toEqual({});
   });
 
@@ -46,7 +53,7 @@ describe('QaTestExtensionExemptionService', () => {
 
     let errored = false;
     try {
-      await service.updateSubmissionStatus('id', 'userId');
+      await service.updateSubmissionStatus('id', 'userId', updatePayload);
     } catch {
       errored = true;
     }

--- a/src/qa-test-extension-exemption/qa-test-extension-exemption.service.ts
+++ b/src/qa-test-extension-exemption/qa-test-extension-exemption.service.ts
@@ -4,6 +4,7 @@ import { EntityManager } from 'typeorm';
 import { QaTeeMaintView } from '../entities/qa-tee-maint-vw.entity';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 @Injectable()
 export class QaTestExtensionExemptionService {
@@ -31,6 +32,7 @@ export class QaTestExtensionExemptionService {
   async updateSubmissionStatus(
     id: string,
     userId: string,
+    payload: QaUpdateDto,
   ): Promise<QaTeeMaintView> {
     let recordToUpdate: QaTeeMaintView;
 
@@ -40,9 +42,10 @@ export class QaTestExtensionExemptionService {
         `UPDATE camdecmps.test_extension_exemption 
       SET submission_availability_cd = $2,
       userid = $3,
-      update_date = $4
+      update_date = $4,
+      resub_explanation = $5
       WHERE test_extension_exemption_id = $1`,
-        [id, 'REQUIRE', userId, currentDateTime()],
+        [id, 'REQUIRE', userId, currentDateTime(), payload?.resubExplanation],
       );
       recordToUpdate = await this.manager.findOne(QaTeeMaintView, id);
       if (!recordToUpdate)

--- a/src/qa-test-summary/qa-test-summary.controller.spec.ts
+++ b/src/qa-test-summary/qa-test-summary.controller.spec.ts
@@ -8,10 +8,12 @@ import { QaCertMaintParamsDto } from '../dto/qa-cert-maint-params.dto';
 import { EntityManager } from 'typeorm';
 import { QaTestSummaryMaintView } from '../entities/qa-test-summary-maint-vw.entity';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 describe('QaTestSummaryController', () => {
   let controller: QaTestSummaryController;
   let service: QaTestSummaryService;
+  let updatePayload;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +24,7 @@ describe('QaTestSummaryController', () => {
 
     controller = module.get<QaTestSummaryController>(QaTestSummaryController);
     service = module.get<QaTestSummaryService>(QaTestSummaryService);
+    updatePayload = new QaUpdateDto();
   });
 
   it('should be defined', () => {
@@ -48,7 +51,9 @@ describe('QaTestSummaryController', () => {
     };
     jest.spyOn(service, 'updateSubmissionStatus').mockResolvedValue(record);
 
-    expect(await controller.updateSubmissionStatus('id', user)).toEqual(record);
+    expect(
+      await controller.updateSubmissionStatus('id', user, updatePayload),
+    ).toEqual(record);
   });
 
   it('should return data for deleteQATestSummaryData controller method', async () => {

--- a/src/qa-test-summary/qa-test-summary.controller.ts
+++ b/src/qa-test-summary/qa-test-summary.controller.ts
@@ -1,5 +1,12 @@
 import { Controller, UseGuards } from '@nestjs/common';
-import { Get, Put, Delete, Query, Param } from '@nestjs/common/decorators';
+import {
+  Get,
+  Put,
+  Delete,
+  Query,
+  Param,
+  Body,
+} from '@nestjs/common/decorators';
 import {
   ApiBearerAuth,
   ApiOkResponse,
@@ -17,6 +24,7 @@ import { QaTestSummaryMaintView } from '../entities/qa-test-summary-maint-vw.ent
 import { QaCertMaintParamsDto } from '../dto/qa-cert-maint-params.dto';
 import { User } from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 @Controller()
 @ApiSecurity('APIKey')
 @ApiTags('QA Test Data Maintenance')
@@ -52,8 +60,9 @@ export class QaTestSummaryController {
   updateSubmissionStatus(
     @Param('id') id: string,
     @User() user: CurrentUser,
+    @Body() payload: QaUpdateDto,
   ): Promise<QaTestSummaryMaintView> {
-    return this.service.updateSubmissionStatus(id, user.userId);
+    return this.service.updateSubmissionStatus(id, user.userId, payload);
   }
 
   @Delete(':id')

--- a/src/qa-test-summary/qa-test-summary.service.spec.ts
+++ b/src/qa-test-summary/qa-test-summary.service.spec.ts
@@ -2,10 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { QaTestSummaryService } from './qa-test-summary.service';
 import { EntityManager } from 'typeorm';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 
 describe('QaTestSummaryService', () => {
   let service: QaTestSummaryService;
   let entityManager: EntityManager;
+  let updatePayload;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -14,6 +16,7 @@ describe('QaTestSummaryService', () => {
 
     service = module.get<QaTestSummaryService>(QaTestSummaryService);
     entityManager = module.get<EntityManager>(EntityManager);
+    updatePayload = new QaUpdateDto();
   });
 
   it('should be defined', () => {
@@ -31,7 +34,11 @@ describe('QaTestSummaryService', () => {
     // jest.spyOn(entityManager, 'query').mockResolvedValue([[], 1]);
     jest.spyOn(entityManager, 'findOne').mockResolvedValue({});
 
-    const result = await service.updateSubmissionStatus('id', 'userId');
+    const result = await service.updateSubmissionStatus(
+      'id',
+      'userId',
+      updatePayload,
+    );
     expect(result).toEqual({});
   });
 
@@ -44,7 +51,7 @@ describe('QaTestSummaryService', () => {
 
     let errored = false;
     try {
-      await service.updateSubmissionStatus('id', 'userId');
+      await service.updateSubmissionStatus('id', 'userId', updatePayload);
     } catch {
       errored = true;
     }

--- a/src/qa-test-summary/qa-test-summary.service.ts
+++ b/src/qa-test-summary/qa-test-summary.service.ts
@@ -4,6 +4,7 @@ import { QaTestSummaryMaintView } from '../entities/qa-test-summary-maint-vw.ent
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { QaUpdateDto } from '../dto/qa-update.dto';
 @Injectable()
 export class QaTestSummaryService {
   constructor(
@@ -30,6 +31,7 @@ export class QaTestSummaryService {
   async updateSubmissionStatus(
     id: string,
     userId: string,
+    payload: QaUpdateDto,
   ): Promise<QaTestSummaryMaintView> {
     let recordToUpdate: QaTestSummaryMaintView;
 
@@ -40,9 +42,10 @@ export class QaTestSummaryService {
           `UPDATE camdecmps.qa_supp_data 
             SET submission_availability_cd = $2,
             userid = $3,
-            update_date = $4
+            update_date = $4,
+            resub_explanation = $5
             WHERE test_sum_id = $1;`,
-          [id, 'REQUIRE', userId, currentDateTime()],
+          [id, 'REQUIRE', userId, currentDateTime(), payload?.resubExplanation],
         );
 
         // UPDATE WORKSPACE TABLE
@@ -50,9 +53,10 @@ export class QaTestSummaryService {
           `UPDATE camdecmpswks.qa_supp_data 
             SET submission_availability_cd = $2,
             userid = $3,
-            update_date = $4
+            update_date = $4,
+            resub_explanation = $5
             WHERE test_sum_id = $1;`,
-          [id, 'REQUIRE', userId, currentDateTime()],
+          [id, 'REQUIRE', userId, currentDateTime(), payload.resubExplanation],
         );
       });
 


### PR DESCRIPTION
## Pull Request

```

- Modify camdecmpswks.qa_cert_event, camdecmps.qa_supp_data, camdecmpswks.qa_supp_data, camdecmpswks.test_extension_exemption tables to add resub_explanation columns 
- Modify camdecmps.vw_qa_test_summary_maintenance, camdecmps.vw_qa_test_extens_exempt_maintenance, camdecmps.vw_qa_cert_event_maintenance views to add resub_explanation
- Add { "resubExplanation": "string } payload to PUT requests
- Update GET request to return resubExplanation
- Update unit tests 

```
