### PR TITLE
fix/5846 - EM Submission Access (Lamar)

### DIFF
--- a/src/dto/em-submission-access.params.dto.ts
+++ b/src/dto/em-submission-access.params.dto.ts
@@ -11,6 +11,7 @@ import { Plant } from '../entities/plant.entity';
 import { IsValidCode, IsInRange } from '@us-epa-camd/easey-common/pipes';
 import { MonitorPlan } from '../entities/monitor-plan.entity';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
+import {FindOneOptions} from "typeorm/find-options/FindOneOptions";
 
 export class EmSubmissionAccessParamsDTO {
   @ApiProperty()
@@ -19,6 +20,12 @@ export class EmSubmissionAccessParamsDTO {
     message: (args: ValidationArguments) => {
       return `The ${args.property} is not valid. Refer to the list of available facilityRecordIds for valid values '/facilities-mgmt/facilities'`;
     },
+  },(args: ValidationArguments): FindOneOptions<Plant> => {
+    return {
+      where: {
+        orisCode: args.value,
+      },
+    };
   })
   @Type(() => Number)
   orisCode?: number;


### PR DESCRIPTION
Updates validation of the orisCode in the EmSubmissionAccessParamsDTO to be checked against plant.oris_code instead of plant-fac_id.  Before this fix, validation of the Facility Name / ID selection when clicking the Apply Filter on the Emission Submission Access screen only passed if the there was a record in camd.plant with fac_id equal to the oris_code of the selected facility.