### PR TITLE
Fix/6102 forbidden resource errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ data-dictionary.json
 .DS_Store
 .env
 .env.*
+.envrc
 
 npm-debug.log*
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data-dictionary.json
 # dependencies
 /node_modules
 /npm-packages-offline-cache
+.npmrc
 
 # production
 /dist

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "5.1.2",
     "@nestjs/typeorm": "8.0.3",
-    "@us-epa-camd/easey-common": "^17.2.8",
+    "@us-epa-camd/easey-common": "^17.2.12",
     "axios": "^0.27.2",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -90,8 +90,17 @@ export default registerAs('app', () => ({
   ),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_CAMD_SERVICES_ENABLE_DEBUG'),
-  // NEEDS TO BE SET IN .ENV FILE FOR LOCAL DEVELOPMENT
-  // FORMAT: { "userId": "", "roles": [ { "orisCode": 3, "role": "P" } ] }
+  /**
+   * Needs to be set in .env file for local development if `EASEY_EMISSIONS_API_ENABLE_AUTH_TOKEN` is false.
+   * Format:
+   *   {
+   *       "facilities": [
+   *           { "facId": number, "orisCode": number, "permissions": string[] }
+   *       ],
+   *       "roles": <"Preparer" | "Submitter" | "Sponsor">[],
+   *       "userId": string
+   *   }
+   */
   currentUser: getConfigValue(
     'EASEY_CAMD_SERVICES_CURRENT_USER',
     '{"userId": ""}',

--- a/src/mats-file-upload/mats-file-upload.controller.ts
+++ b/src/mats-file-upload/mats-file-upload.controller.ts
@@ -33,7 +33,7 @@ export class MatsFileUploadController {
       enforceCheckout: true,
       pathParam: 'monPlanId',
       requiredRoles: ['Submitter', 'Preparer', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.MonitorPlan,
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2308,10 +2308,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@^17.2.8":
-  version "17.2.8"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.2.8/13f168b52cd98fdf4047c60abef4f233fce16ba7#13f168b52cd98fdf4047c60abef4f233fce16ba7"
-  integrity sha512-OUh0NCDlfLqMMUNx4FAYkBk6+vfQeRITQEc1BTf3JZVTxSdff7+Pdowg2mJ/uAB83iNAGrSQgtmKzGQdxSvKdA==
+"@us-epa-camd/easey-common@^17.2.12":
+  version "17.2.12"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.2.12/68bb9cc590a6375b56c3a2457c27d42479e978f4#68bb9cc590a6375b56c3a2457c27d42479e978f4"
+  integrity sha512-dYMdWPTdqNc0fvpk1UajksdlE7uA/KccRr529bobxHNG2y9a5b9DWiNaRt9BwtTFpy2OSgWQqJF+LO/ENwu87w==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
## Main Changes

- Removed values from the `permissionsForFacility` array that are no longer returned from the permissions API (`DPQA`).
- Updated the comment documenting the `EASEY_CAMD_SERVICES_CURRENT_USER` environment variable.

## Note
These updates were made while working on https://github.com/US-EPA-CAMD/easey-ui/issues/6102, but they are not needed to resolve that ticket (the actual fix is in [`US-EPA-CAMD/easey-common#137`](https://github.com/US-EPA-CAMD/easey-common/pull/137)).
