### PR TITLE
fix:incorrect componentid in the email

### DIFF
--- a/src/mail/mail-eval.service.spec.ts
+++ b/src/mail/mail-eval.service.spec.ts
@@ -89,7 +89,7 @@ describe('Mail Eval Service', () => {
     } as any as EntityManager;
 
     jest.spyOn(service, 'returnManager').mockReturnValue(mockManager);
-    expect(await service.getSystemComponentIdentifier('', '')).toEqual(
+    expect(await service.getSystemComponentIdentifier(ms.systemIdentifier, '')).toEqual(
       'MOCK-S',
     );
   });

--- a/src/mail/mail-eval.service.ts
+++ b/src/mail/mail-eval.service.ts
@@ -36,7 +36,7 @@ export class MailEvalService {
     private readonly configService: ConfigService,
     private dataSetService: DataSetService,
     private copyOfRecordService: CopyOfRecordService,
-  ) {}
+  ) { }
 
   returnManager() {
     return getManager();
@@ -53,10 +53,13 @@ export class MailEvalService {
     monitorSystem: string,
     componentId: string,
   ) {
-    const ms = await this.returnManager().findOne(MonitorSystem, monitorSystem);
-    if (ms && ms.systemIdentifier) {
-      return ms.systemIdentifier;
+    if (monitorSystem) {
+      const ms = await this.returnManager().findOne(MonitorSystem, monitorSystem);
+      if (ms && ms.systemIdentifier) {
+        return ms.systemIdentifier;
+      }
     }
+
     const c = await this.returnManager().findOne(Component, componentId);
     return c.componentIdentifier;
   }
@@ -395,7 +398,7 @@ export class MailEvalService {
 
     //Handle QA 
     const testSumRecords = records.filter(r => r.processCode === "QA" && r.testSumIdentifier != null);
-    if(testSumRecords.length > 0){
+    if (testSumRecords.length > 0) {
       const paramsTestSum = new ReportParamsDTO();
       paramsTestSum.facilityId = set.orisCode;
 
@@ -416,7 +419,7 @@ export class MailEvalService {
     }
 
     const qaCertRecords = records.filter(r => r.processCode === "QA" && r.qaCertEventIdentifier != null);
-    if(qaCertRecords.length > 0){
+    if (qaCertRecords.length > 0) {
       const paramsCert = new ReportParamsDTO();
       paramsCert.facilityId = set.orisCode;
 
@@ -437,13 +440,13 @@ export class MailEvalService {
     }
 
     const teeRecords = records.filter(r => r.processCode === "QA" && r.testExtensionExemptionIdentifier != null);
-    if(teeRecords.length > 0){
+    if (teeRecords.length > 0) {
       const paramsTee = new ReportParamsDTO();
       paramsTee.facilityId = set.orisCode;
 
       let title = 'TEE_EVAL';
       paramsTee.reportCode = 'TEE_EVAL';
-      paramsTee.qceId = qaCertRecords.map(qce => qce.qaCertEventIdentifier);
+      paramsTee.teeId = teeRecords.map(qce => qce.testExtensionExemptionIdentifier);
 
       const reportInformationTEE = await this.dataSetService.getDataSet(
         paramsTee,
@@ -458,51 +461,51 @@ export class MailEvalService {
     }
 
     for (const rec of records) {
-      if(rec.processCode !== "QA"){
-      const params = new ReportParamsDTO();
-      params.facilityId = set.orisCode;
+      if (rec.processCode !== "QA") {
+        const params = new ReportParamsDTO();
+        params.facilityId = set.orisCode;
 
-      let titleContext = '';
+        let titleContext = '';
 
-      // Add Eval Report
-      if (rec.processCode === 'MP') {
-        titleContext = 'MP_EVAL_' + set.monPlanIdentifier;
-        params.reportCode = 'MP_EVAL';
-        params.monitorPlanId = set.monPlanIdentifier;
-      } 
-      else if (rec.processCode === 'EM') {
-        const rptPeriod: ReportingPeriod = await this.returnManager().findOne(
-          ReportingPeriod,
-          {
-            where: { rptPeriodIdentifier: rec.rptPeriodIdentifier },
-          },
+        // Add Eval Report
+        if (rec.processCode === 'MP') {
+          titleContext = 'MP_EVAL_' + set.monPlanIdentifier;
+          params.reportCode = 'MP_EVAL';
+          params.monitorPlanId = set.monPlanIdentifier;
+        }
+        else if (rec.processCode === 'EM') {
+          const rptPeriod: ReportingPeriod = await this.returnManager().findOne(
+            ReportingPeriod,
+            {
+              where: { rptPeriodIdentifier: rec.rptPeriodIdentifier },
+            },
+          );
+
+          params.reportCode = 'EM_EVAL';
+          params.monitorPlanId = set.monPlanIdentifier;
+          params.year = rptPeriod.calendarYear;
+          params.quarter = rptPeriod.quarter;
+
+          titleContext =
+            'EM_EVAL_' +
+            params.monitorPlanId +
+            '_' +
+            params.year +
+            'q' +
+            params.quarter;
+        }
+
+        const reportInformation = await this.dataSetService.getDataSet(
+          params,
+          true,
         );
 
-        params.reportCode = 'EM_EVAL';
-        params.monitorPlanId = set.monPlanIdentifier;
-        params.year = rptPeriod.calendarYear;
-        params.quarter = rptPeriod.quarter;
-
-        titleContext =
-          'EM_EVAL_' +
-          params.monitorPlanId +
-          '_' +
-          params.year +
-          'q' +
-          params.quarter;
+        documents.push({
+          filename: `${set.orisCode}_${titleContext}.html`,
+          content:
+            this.copyOfRecordService.generateCopyOfRecord(reportInformation),
+        });
       }
-
-      const reportInformation = await this.dataSetService.getDataSet(
-        params,
-        true,
-      );
-
-      documents.push({
-        filename: `${set.orisCode}_${titleContext}.html`,
-        content:
-          this.copyOfRecordService.generateCopyOfRecord(reportInformation),
-      });
-    }
     }
   }
 

--- a/src/mail/mail-eval.service.ts
+++ b/src/mail/mail-eval.service.ts
@@ -446,7 +446,7 @@ export class MailEvalService {
 
       let title = 'TEE_EVAL';
       paramsTee.reportCode = 'TEE_EVAL';
-      paramsTee.teeId = teeRecords.map(qce => qce.testExtensionExemptionIdentifier);
+      paramsTee.teeId = teeRecords.map(tee => tee.testExtensionExemptionIdentifier);
 
       const reportInformationTEE = await this.dataSetService.getDataSet(
         paramsTee,


### PR DESCRIPTION
## Ticket
[Incorrect system/component Id on Evaluation and Submission Confirmation Reports for NONQADB TEE](https://github.com/US-EPA-CAMD/easey-ui/issues/6066)


## Change

- Added a if condition for `monSystemIdentifier` in `getSystemComponentIdentifier`;  without if condition: it will take camdecmpswks.monitor_system's first data.
- Fixed wrong Report Parameter assigned for TEE records. `paramsTee.teeId = teeRecords.map(tee => tee.testExtensionExemptionIdentifier);`

![6066-monplanError](https://github.com/US-EPA-CAMD/easey-camd-services/assets/108369391/46dfcab7-cd4e-4206-8678-0f6fb7e30175)
