### PR TITLE
Fix/6185 typeorm fixes

### DIFF
--- a/src/copy-of-record/copy-of-record.service.ts
+++ b/src/copy-of-record/copy-of-record.service.ts
@@ -1,6 +1,7 @@
 import { ReportDetailDTO } from './../dto/report-detail.dto';
 import { Injectable, StreamableFile } from '@nestjs/common';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { EntityManager } from 'typeorm';
 import { copyOfRecordTemplate } from './template';
 import { certTemplate } from './cert-template';
 import { ReportDTO } from '../dto/report.dto';
@@ -17,6 +18,7 @@ export class CopyOfRecordService {
   constructor(
     private readonly logger: Logger,
     private dataService: DataSetService,
+    private readonly entityManager: EntityManager,
   ) {}
 
   addDocumentHeader(content: string, title: string): string {
@@ -246,7 +248,7 @@ export class CopyOfRecordService {
 
     const htmlContent = this.generateCopyOfRecord(reportInformation, true);
 
-    const plant: Plant = await Plant.findOneBy({
+    const plant: Plant = await this.entityManager.findOneBy(Plant, {
       orisCode: params.facilityId,
     });
 

--- a/src/mats-file-upload/mats-file-upload.service.spec.ts
+++ b/src/mats-file-upload/mats-file-upload.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from 'typeorm';
 import { MatsFileUploadService } from './mats-file-upload.service';
 import { ConfigService } from '@nestjs/config';
 import { MonitorPlan } from '../entities/monitor-plan.entity';
@@ -10,13 +11,15 @@ jest.mock('@aws-sdk/client-s3');
 
 describe('MatsFileUploadService', () => {
   let service: MatsFileUploadService;
+  let entityManager: EntityManager;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ConfigService, MatsFileUploadService],
+      providers: [ConfigService, MatsFileUploadService, EntityManager],
     }).compile();
 
     service = module.get(MatsFileUploadService);
+    entityManager = module.get(EntityManager);
   });
 
   it('should be defined', async () => {
@@ -35,8 +38,8 @@ describe('MatsFileUploadService', () => {
     const mockPlan: MonitorPlan = { plant: new Plant() } as any;
     const testTypecode: TestTypeCode = { testTypeCodeDescription: '' } as any;
 
-    jest.spyOn(MonitorPlan, 'findOne').mockResolvedValue(mockPlan);
-    jest.spyOn(TestTypeCode, 'findOneBy').mockResolvedValue(testTypecode);
+    jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockPlan);
+    jest.spyOn(entityManager, 'findOneBy').mockResolvedValue(testTypecode);
     jest.spyOn(service, 'uploadFile').mockResolvedValue(null);
 
     jest.spyOn(MatsBulkFile, 'create').mockReturnValue(null);

--- a/src/mats-file-upload/mats-file-upload.service.ts
+++ b/src/mats-file-upload/mats-file-upload.service.ts
@@ -1,15 +1,20 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { MonitorPlan } from '../entities/monitor-plan.entity';
+import { EntityManager } from 'typeorm';
+
 import { MatsBulkFile } from '../entities/mats-bulk-file.entity';
+import { MonitorPlan } from '../entities/monitor-plan.entity';
 import { TestTypeCode } from '../entities/test-type-code.entity';
 
 @Injectable()
 export class MatsFileUploadService {
   private s3Client: S3Client;
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly entityManager: EntityManager,
+  ) {}
 
   async uploadFile(file: Buffer, bucketLocation: string) {
     this.s3Client = new S3Client({
@@ -34,13 +39,19 @@ export class MatsFileUploadService {
     testNumber: string,
     userId: string,
   ) {
-    const monitorPlan: MonitorPlan = await MonitorPlan.findOne({
-      where: { monPlanIdentifier: monPlanId },
-      relations: ['plant'],
-    });
-    const testTypeCodeEntity: TestTypeCode = await TestTypeCode.findOneBy({
-      testTypeCode,
-    });
+    const monitorPlan: MonitorPlan = await this.entityManager.findOne(
+      MonitorPlan,
+      {
+        where: { monPlanIdentifier: monPlanId },
+        relations: ['plant'],
+      },
+    );
+    const testTypeCodeEntity: TestTypeCode = await this.entityManager.findOneBy(
+      TestTypeCode,
+      {
+        testTypeCode,
+      },
+    );
 
     const date = new Date();
     const year = date.getFullYear();

--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -284,7 +284,7 @@ export class SubmissionService {
       .now;
 
     dto.submissionLogs = await this.combinedSubmissionMap.many(
-      await CombinedSubmissions.findBy({
+      await this.entityManager.findBy(CombinedSubmissions, {
         submissionEndStateStageTime: MoreThanOrEqual(new Date(queryTime)),
         statusCode: 'COMPLETE',
         processCode: 'EM',
@@ -292,7 +292,7 @@ export class SubmissionService {
     );
 
     dto.emissionReports = await this.emissionsLastUpdatedMap.many(
-      await EmissionEvaluationGlobal.findBy({
+      await this.entityManager.findBy(EmissionEvaluationGlobal, {
         lastUpdated: MoreThanOrEqual(new Date(queryTime).toISOString()),
       }),
     );


### PR DESCRIPTION
## Main Changes

- Fixed several instances where repository methods were being called on the repository class itself rather than an instance of one, which is no longer allowed in TypeORM v0.3.0.
