### PR TITLE
fix(6185): two more instances of bare entity method calls

### DIFF
--- a/src/mats-file-upload/mats-file-upload.service.spec.ts
+++ b/src/mats-file-upload/mats-file-upload.service.spec.ts
@@ -42,8 +42,8 @@ describe('MatsFileUploadService', () => {
     jest.spyOn(entityManager, 'findOneBy').mockResolvedValue(testTypecode);
     jest.spyOn(service, 'uploadFile').mockResolvedValue(null);
 
-    jest.spyOn(MatsBulkFile, 'create').mockReturnValue(null);
-    jest.spyOn(MatsBulkFile, 'save').mockImplementation(mockSave);
+    jest.spyOn(entityManager, 'create').mockReturnValue(null);
+    jest.spyOn(entityManager, 'save').mockImplementation(mockSave);
 
     const file: Express.Multer.File = {
       buffer: Buffer.from(''),

--- a/src/mats-file-upload/mats-file-upload.service.ts
+++ b/src/mats-file-upload/mats-file-upload.service.ts
@@ -80,21 +80,24 @@ export class MatsFileUploadService {
 
     await this.uploadFile(file.buffer, bucketLocation);
 
-    const matsBulkFileRecord: MatsBulkFile = MatsBulkFile.create({
-      location: locId,
-      facIdentifier: monitorPlan.plant.facIdentifier,
-      testTypeGroup: testTypeCode,
-      testTypeGroupDescription: testTypeCodeEntity.testTypeCodeDescription,
-      orisCode: monitorPlan.plant.orisCode,
-      facilityName: monitorPlan.plant.facilityName,
-      monPlanIdentifier: monPlanId,
-      testNumber,
-      fileName: file.originalname,
-      userId,
-      bucketLocation: bucketLocation,
-      addDate: new Date(),
-    });
+    const matsBulkFileRecord: MatsBulkFile = this.entityManager.create(
+      MatsBulkFile,
+      {
+        location: locId,
+        facIdentifier: monitorPlan.plant.facIdentifier,
+        testTypeGroup: testTypeCode,
+        testTypeGroupDescription: testTypeCodeEntity.testTypeCodeDescription,
+        orisCode: monitorPlan.plant.orisCode,
+        facilityName: monitorPlan.plant.facilityName,
+        monPlanIdentifier: monPlanId,
+        testNumber,
+        fileName: file.originalname,
+        userId,
+        bucketLocation: bucketLocation,
+        addDate: new Date(),
+      },
+    );
 
-    await MatsBulkFile.save(matsBulkFileRecord);
+    await this.entityManager.save(MatsBulkFile, matsBulkFileRecord);
   }
 }


### PR DESCRIPTION
## Main Changes

- Addressed two more instances of method calls on bare TypeORM entity classes (versus accessing them through an instantiated EntityManager or repository).
