### PR TITLE
Fix/6185 explicit nulls

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "17.4.0",
+    "@us-epa-camd/easey-common": "17.4.1",
     "axios": "^0.28.0",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",

--- a/src/em-submission-access/em-submission-access.service.spec.ts
+++ b/src/em-submission-access/em-submission-access.service.spec.ts
@@ -19,7 +19,7 @@ const mockViewRepository = () => ({
 
 const mockRepository = () => ({
   save: jest.fn(),
-  create: jest.fn(),
+  create: jest.fn().mockReturnValue(new EmSubmissionAccess()),
   findOneBy: jest.fn(),
 });
 

--- a/src/em-submission-access/em-submission-access.service.ts
+++ b/src/em-submission-access/em-submission-access.service.ts
@@ -51,7 +51,7 @@ export class EmSubmissionAccessService {
       });
       await this.repository.save(entity);
       let emSubmissionAccess = await this.viewRepository.findOneBy({
-        id: entity?.id,
+        id: entity.id,
       });
       const dto = await this.map.one(emSubmissionAccess);
       return dto;
@@ -88,7 +88,7 @@ export class EmSubmissionAccessService {
     }
 
     let emSubmissionAccess = await this.viewRepository.findOneBy({
-      id: recordToUpdate?.id,
+      id: recordToUpdate.id,
     });
 
     const dto = await this.map.one(emSubmissionAccess);

--- a/src/error-suppressions/error-suppressions.service.spec.ts
+++ b/src/error-suppressions/error-suppressions.service.spec.ts
@@ -16,7 +16,7 @@ const mockRepository = () => ({
   getErrorSuppressions: jest.fn(),
   findOne: jest.fn(),
   save: jest.fn(),
-  create: jest.fn(),
+  create: jest.fn().mockReturnValue(new EsSpec()),
 });
 const mockMap = () => ({
   many: jest.fn(),

--- a/src/error-suppressions/error-suppressions.service.ts
+++ b/src/error-suppressions/error-suppressions.service.ts
@@ -69,7 +69,7 @@ export class ErrorSuppressionsService {
 
       await this.repository.save(entity);
       const errorSuppression = await this.repository.findOne({
-        where: { id: entity?.id },
+        where: { id: entity.id },
         relations: [
           'checkCatalogResult',
           'plant',

--- a/src/mail/mail-eval.service.spec.ts
+++ b/src/mail/mail-eval.service.spec.ts
@@ -200,6 +200,7 @@ describe('Mail Eval Service', () => {
       .spyOn(service, 'getReportColors')
       .mockReturnValue(['#FF6862', '#FF6862']);
     jest.spyOn(service, 'returnManager').mockReturnValue(mockManager);
+    mockEvalList.forEach((e) => (e.testExtensionExemptionIdentifier = 'MOCK'));
     const result = await service.formatTeeContext(
       {},
       mockEvalList,

--- a/src/mail/mail-eval.service.spec.ts
+++ b/src/mail/mail-eval.service.spec.ts
@@ -90,9 +90,9 @@ describe('Mail Eval Service', () => {
     } as any as EntityManager;
 
     jest.spyOn(service, 'returnManager').mockReturnValue(mockManager);
-    expect(await service.getSystemComponentIdentifier(ms.systemIdentifier, '')).toEqual(
-      'MOCK-S',
-    );
+    expect(
+      await service.getSystemComponentIdentifier(ms.systemIdentifier, ''),
+    ).toEqual('MOCK-S');
   });
 
   it('get system / component id correctly with just component present', async () => {
@@ -110,9 +110,9 @@ describe('Mail Eval Service', () => {
     } as any as EntityManager;
 
     jest.spyOn(service, 'returnManager').mockReturnValue(mockManager);
-    expect(await service.getSystemComponentIdentifier('', '')).toEqual(
-      'MOCK-C',
-    );
+    expect(
+      await service.getSystemComponentIdentifier('', 'AAA-AAAAAAA'),
+    ).toEqual('MOCK-C');
   });
 
   it('format test data context correctly', async () => {
@@ -134,6 +134,7 @@ describe('Mail Eval Service', () => {
       .spyOn(service, 'getReportColors')
       .mockReturnValue(['#FF6862', '#FF6862']);
     jest.spyOn(service, 'returnManager').mockReturnValue(mockManager);
+    mockEvalList.forEach((e) => (e.testSumIdentifier = 'MOCK'));
     const result = await service.formatTestDataContext(
       {},
       mockEvalList,
@@ -165,6 +166,7 @@ describe('Mail Eval Service', () => {
       .spyOn(service, 'getReportColors')
       .mockReturnValue(['#FF6862', '#FF6862']);
     jest.spyOn(service, 'returnManager').mockReturnValue(mockManager);
+    mockEvalList.forEach((e) => (e.qaCertEventIdentifier = 'MOCK'));
     const result = await service.formatCertEventsContext(
       {},
       mockEvalList,
@@ -238,7 +240,7 @@ describe('Mail Eval Service', () => {
     const result = await service.formatEmissionsContext(
       {},
       mockEvalList,
-      3,
+      '3',
       1,
       new Map(),
       false,

--- a/src/mail/mail-eval.service.ts
+++ b/src/mail/mail-eval.service.ts
@@ -62,18 +62,20 @@ export class MailEvalService {
         return ms.systemIdentifier;
       }
     }
-    const c = await this.returnManager().findOneBy(Component, {
-      componentId,
-    });
-    return c.componentIdentifier;
+    if (componentId) {
+      const c = await this.returnManager().findOneBy(Component, {
+        componentId,
+      });
+      return c.componentIdentifier;
+    }
   }
 
   async formatTestDataContext(
-    templateContext,
-    records,
-    orisCode,
-    mappedStatusCodes,
-    isSubmission,
+    templateContext: Record<string, any>,
+    records: Array<Evaluation | SubmissionQueue>,
+    orisCode: number | null,
+    mappedStatusCodes: Map<string, string>,
+    isSubmission: boolean,
   ) {
     const testDataKeys = [
       'System / Component Id',
@@ -94,11 +96,12 @@ export class MailEvalService {
       };
       for (const testRecord of records) {
         const newItem: any = {};
-        const testSumRecord: TestSummary | TestSummaryGlobal =
-          await this.returnManager().findOneBy(
+        const testSumRecord: TestSummary | TestSummaryGlobal | null =
+          testRecord.testSumIdentifier &&
+          (await this.returnManager().findOneBy(
             !isSubmission ? TestSummary : TestSummaryGlobal,
             { testSumIdentifier: testRecord.testSumIdentifier },
-          );
+          ));
 
         if (testSumRecord) {
           newItem['System / Component Id'] =
@@ -133,11 +136,11 @@ export class MailEvalService {
   }
 
   async formatCertEventsContext(
-    templateContext,
-    records,
-    orisCode,
-    mappedStatusCodes,
-    isSubmission,
+    templateContext: Record<string, any>,
+    records: Array<Evaluation | SubmissionQueue>,
+    orisCode: number | null,
+    mappedStatusCodes: Map<string, string>,
+    isSubmission: boolean,
   ) {
     const certEventKeys = [
       'System / Component Id',
@@ -156,11 +159,12 @@ export class MailEvalService {
       };
       for (const certRecord of records) {
         const newItem: any = {};
-        const certEventRecord: QaCertEvent | QaCertEventGlobal =
-          await this.returnManager().findOneBy(
+        const certEventRecord: QaCertEvent | QaCertEventGlobal | null =
+          certRecord.qaCertEventIdentifier &&
+          (await this.returnManager().findOneBy(
             !isSubmission ? QaCertEvent : QaCertEventGlobal,
             { qaCertEventIdentifier: certRecord.qaCertEventIdentifier },
-          );
+          ));
 
         if (certEventRecord) {
           newItem['System / Component Id'] =
@@ -193,11 +197,11 @@ export class MailEvalService {
   }
 
   async formatTeeContext(
-    templateContext,
-    records,
-    orisCode,
-    mappedStatusCodes,
-    isSubmission,
+    templateContext: Record<string, any>,
+    records: Array<Evaluation | SubmissionQueue>,
+    orisCode: number | null,
+    mappedStatusCodes: Map<string, string>,
+    isSubmission: boolean,
   ) {
     const teeKeys = [
       'System / Component Id',
@@ -220,14 +224,15 @@ export class MailEvalService {
 
       for (const tee of records) {
         const newItem: any = {};
-        const teeRecord: QaTee | QaTeeGlobal =
-          await this.returnManager().findOneBy(
+        const teeRecord: QaTee | QaTeeGlobal | null =
+          tee.testExtensionExemptionIdentifier &&
+          (await this.returnManager().findOneBy(
             !isSubmission ? QaTee : QaTeeGlobal,
             {
               testExtensionExemptionIdentifier:
                 tee.testExtensionExemptionIdentifier,
             },
-          );
+          ));
         const reportPeriodInfo = await this.returnManager().findOneBy(
           ReportingPeriod,
           { rptPeriodIdentifier: teeRecord.rptPeriodIdentifier },
@@ -267,12 +272,12 @@ export class MailEvalService {
   }
 
   async formatEmissionsContext(
-    templateContext,
-    records,
-    monitorPlanId,
-    orisCode,
-    mappedStatusCodes,
-    isSubmission,
+    templateContext: Record<string, any>,
+    records: Array<Evaluation | SubmissionQueue>,
+    monitorPlanId: string,
+    orisCode: number | null,
+    mappedStatusCodes: Map<string, string>,
+    isSubmission: boolean,
   ) {
     const emissionsKeys = ['Year / Quarter'];
 
@@ -288,13 +293,14 @@ export class MailEvalService {
 
       for (const em of records) {
         const newItem: any = {};
-        const emissionsRecord: any = await this.returnManager().findOneBy(
-          !isSubmission ? EmissionEvaluation : EmissionEvaluationGlobal,
-          {
-            monPlanIdentifier: monitorPlanId,
-            rptPeriodIdentifier: em.rptPeriodIdentifier,
-          },
-        );
+        const emissionsRecord: EmissionEvaluation | EmissionEvaluationGlobal =
+          await this.returnManager().findOneBy(
+            !isSubmission ? EmissionEvaluation : EmissionEvaluationGlobal,
+            {
+              monPlanIdentifier: monitorPlanId,
+              rptPeriodIdentifier: em.rptPeriodIdentifier,
+            },
+          );
 
         if (emissionsRecord) {
           const reportPeriodInfo = await this.returnManager().findOneBy(
@@ -303,12 +309,14 @@ export class MailEvalService {
           );
 
           newItem['Year / Quarter'] = reportPeriodInfo.periodAbbreviation;
-          newItem['evalStatusCode'] = mappedStatusCodes.get(
-            emissionsRecord.evalStatusCode,
-          );
-          const colors = this.getReportColors(emissionsRecord.evalStatusCode);
-          newItem['reportColor'] = colors[0];
-          newItem['reportLineColor'] = colors[1];
+          if (emissionsRecord instanceof EmissionEvaluation) {
+            newItem['evalStatusCode'] = mappedStatusCodes.get(
+              emissionsRecord.evalStatusCode,
+            );
+            const colors = this.getReportColors(emissionsRecord.evalStatusCode);
+            newItem['reportColor'] = colors[0];
+            newItem['reportLineColor'] = colors[1];
+          }
 
           newItem['reportUrl'] = `${this.configService.get<string>(
             'app.ecmpsHost',
@@ -323,7 +331,10 @@ export class MailEvalService {
     return templateContext;
   }
 
-  async formatMATSContext(templateContext, records) {
+  async formatMATSContext(
+    templateContext: Record<string, any>,
+    records: SubmissionQueue[],
+  ) {
     const matsKeys = ['Test Type', 'Test Number', 'File Name'];
 
     if (records.length > 0) {
@@ -334,14 +345,15 @@ export class MailEvalService {
 
       for (const matsRecord of records) {
         const newItem: any = {};
-        const mats: MatsBulkFile = await this.returnManager().findOneBy(
-          MatsBulkFile,
-          { id: matsRecord.matsBulkFileId },
-        );
+        const mats: MatsBulkFile =
+          matsRecord.matsBulkFileId &&
+          (await this.returnManager().findOneBy(MatsBulkFile, {
+            id: matsRecord.matsBulkFileId,
+          }));
 
-        newItem['Test Type'] = mats.testTypeGroupDescription;
-        newItem['Test Number'] = mats.testNumber;
-        newItem['File Name'] = mats.fileName;
+        newItem['Test Type'] = mats?.testTypeGroupDescription;
+        newItem['Test Number'] = mats?.testNumber;
+        newItem['File Name'] = mats?.fileName;
 
         templateContext['mats'].items.push(newItem);
       }
@@ -405,8 +417,8 @@ export class MailEvalService {
   }
 
   async buildEvalReports(
-    set: EvaluationSet,
-    records: Evaluation[],
+    set: EvaluationSet | SubmissionSet,
+    records: Array<Evaluation | SubmissionQueue>,
     documents: object[],
   ) {
     //Handle QA
@@ -497,14 +509,15 @@ export class MailEvalService {
           params.monitorPlanId = set.monPlanIdentifier;
         } else if (rec.processCode === 'EM') {
           const rptPeriod: ReportingPeriod =
-            await this.returnManager().findOneBy(ReportingPeriod, {
+            rec.rptPeriodIdentifier &&
+            (await this.returnManager().findOneBy(ReportingPeriod, {
               rptPeriodIdentifier: rec.rptPeriodIdentifier,
-            });
+            }));
 
           params.reportCode = 'EM_EVAL';
           params.monitorPlanId = set.monPlanIdentifier;
-          params.year = rptPeriod.calendarYear;
-          params.quarter = rptPeriod.quarter;
+          params.year = rptPeriod?.calendarYear;
+          params.quarter = rptPeriod?.quarter;
 
           titleContext =
             'EM_EVAL_' +
@@ -562,8 +575,8 @@ export class MailEvalService {
 
     let subject;
     let template;
-    let setRecord;
-    let records;
+    let setRecord: SubmissionSet | EvaluationSet;
+    let records: Array<SubmissionQueue | Evaluation>;
 
     let templateContext: any = {};
 
@@ -633,9 +646,11 @@ export class MailEvalService {
     const plant = await this.returnManager().findOneBy(Plant, {
       facIdentifier: mpRecord.facIdentifier,
     });
-    const county = await this.returnManager().findOneBy(CountyCode, {
-      countyCode: plant.countyCode,
-    });
+    const county =
+      plant.countyCode &&
+      (await this.returnManager().findOneBy(CountyCode, {
+        countyCode: plant.countyCode,
+      }));
 
     templateContext['monitorPlan'] = {
       keys: mpKeys,
@@ -645,7 +660,7 @@ export class MailEvalService {
           ['Configuration']: setRecord.configuration,
           ['Oris Code']: plant.orisCode,
           ['State Code']: plant.state,
-          ['County']: county.countyName,
+          ['County']: county?.countyName,
           ['Longitude']: plant.longitude,
           ['Latitude']: plant.latitude,
         },
@@ -730,7 +745,7 @@ export class MailEvalService {
       );
       templateContext = await this.formatMATSContext(
         templateContext,
-        matsDataChildRecords,
+        matsDataChildRecords as SubmissionQueue[],
       );
     }
 

--- a/src/mail/mail-eval.service.ts
+++ b/src/mail/mail-eval.service.ts
@@ -233,10 +233,11 @@ export class MailEvalService {
                 tee.testExtensionExemptionIdentifier,
             },
           ));
-        const reportPeriodInfo = await this.returnManager().findOneBy(
-          ReportingPeriod,
-          { rptPeriodIdentifier: teeRecord.rptPeriodIdentifier },
-        );
+        const reportPeriodInfo =
+          teeRecord &&
+          (await this.returnManager().findOneBy(ReportingPeriod, {
+            rptPeriodIdentifier: teeRecord.rptPeriodIdentifier,
+          }));
 
         if (teeRecord) {
           newItem['System / Component Id'] =
@@ -244,7 +245,7 @@ export class MailEvalService {
               teeRecord.monSystemIdentifier,
               teeRecord.componentIdentifier,
             );
-          newItem['Year / Quarter'] = reportPeriodInfo.periodAbbreviation;
+          newItem['Year / Quarter'] = reportPeriodInfo?.periodAbbreviation;
           newItem['Fuel Code'] = teeRecord.fuelCode;
           newItem['Extension Exemption Code'] = teeRecord.extensExemptCode;
           newItem['Hours Used'] = teeRecord.hoursUsed;

--- a/src/mail/mail-template.service.ts
+++ b/src/mail/mail-template.service.ts
@@ -85,9 +85,11 @@ export class MailTemplateService {
       });
       if (record) {
         //Call into the template email service
-        const template = await this.entityManager.findOneBy(EmailTemplate, {
-          templateIdentifier: record.templateIdentifier,
-        });
+        const template =
+          record.templateIdentifier &&
+          (await this.entityManager.findOneBy(EmailTemplate, {
+            templateIdentifier: record.templateIdentifier,
+          }));
 
         let context; //Extract context
         if (record.context) {

--- a/src/submission/submission-process.service.ts
+++ b/src/submission/submission-process.service.ts
@@ -171,15 +171,14 @@ export class SubmissionProcessService {
         const emRecord = records.find((r) => r.processCode === 'EM');
         params.reportCode = 'EM';
         params.monitorPlanId = set.monPlanIdentifier;
-        const rptPeriod: ReportingPeriod = await this.returnManager().findOneBy(
-          ReportingPeriod,
-          {
+        const rptPeriod: ReportingPeriod =
+          emRecord.rptPeriodIdentifier &&
+          (await this.returnManager().findOneBy(ReportingPeriod, {
             rptPeriodIdentifier: emRecord.rptPeriodIdentifier,
-          },
-        );
+          }));
 
-        params.year = rptPeriod.calendarYear;
-        params.quarter = rptPeriod.quarter;
+        params.year = rptPeriod?.calendarYear;
+        params.quarter = rptPeriod?.quarter;
 
         titleContext =
           'EM_' +

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,10 +2310,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@17.4.0":
-  version "17.4.0"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.0/a3de0d7745b292b29fea5aedf961a112e96f109a#a3de0d7745b292b29fea5aedf961a112e96f109a"
-  integrity sha512-KhhdkCArNIYGlgSDOqjx7x0hQm/GEPygJoKIBFWxJ9k7Llrwy2mt+DU4P6wp+LqfdJgfM+7sTzKnSNY4xIjPIQ==
+"@us-epa-camd/easey-common@17.4.1":
+  version "17.4.1"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.1/f48111f38d5204b5d7d308a7dffc9c202f0e083e#f48111f38d5204b5d7d308a7dffc9c202f0e083e"
+  integrity sha512-rgU7sceWwUiavS4QDnE4ntLPQJzY8zjK1eT042QJH/UXcHYkE22LQQRW4toU+g4LTknFa3NvvjS3Az52B4vHAA==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
## Main Changes

- The `IsNull()` helper must be explicitly used for `null` values in TypeORM `find*` methods version ^0.3.0. In cases where `null` values didn't make sense, I instead switched to conditionally executing the query.