### PR TITLE
fix:remove lat/log and remove evalutaion status code link

### DIFF
--- a/src/mail/mail-eval.service.ts
+++ b/src/mail/mail-eval.service.ts
@@ -570,8 +570,6 @@ export class MailEvalService {
       'Oris Code',
       'State Code',
       'County',
-      'Longitude',
-      'Latitude',
     ];
 
     let subject;
@@ -662,8 +660,6 @@ export class MailEvalService {
           ['Oris Code']: plant.orisCode,
           ['State Code']: plant.state,
           ['County']: county?.countyName,
-          ['Longitude']: plant.longitude,
-          ['Latitude']: plant.latitude,
         },
       ],
     };

--- a/src/mail/templates/massEvaluationTemplate.hbs
+++ b/src/mail/templates/massEvaluationTemplate.hbs
@@ -12,7 +12,7 @@
     solid #ddd; padding: 8px; } table tr:nth-child(even){background-color:
     #f2f2f2;} table th { padding-top: 12px; padding-bottom: 12px; text-align:
     left; background-color: white; color: black; } a{padding: 5px; border-left: .5rem solid; font-size: 1.06rem; line-height: 1.5;}
-    h3{margin-top: 25px;}
+    h3{margin-top: 25px;} p{display: inline; padding: 5px; border-left: .5rem solid; font-size: 1.06rem; line-height: 1.5;}
   </style>
 
   <body>
@@ -35,7 +35,7 @@
         {{/each}}
       </table>
       {{#if monitorPlan.items.evalStatus}}
-        <h3> Evaluation Status Code: <a style="background-color: {{monitorPlan.items.reportColor}}; border-left-color: {{monitorPlan.items.reportLineColor}};" href="{{monitorPlan.items.reportUrl}}"> {{monitorPlan.items.evalStatus}} </a> </h3>
+        <h3> Evaluation Status Code: <p style="background-color: {{monitorPlan.items.reportColor}}; border-left-color: {{monitorPlan.items.reportLineColor}};"> {{monitorPlan.items.evalStatus}} </p> </h3>
       {{/if}}
     </div>
     {{#if testData}}
@@ -52,7 +52,7 @@
                   <td> {{lookup .. this}} </td>
                 {{/if}}
               {{/each}}
-              <td> <a style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};" href="{{this.reportUrl}}"> {{this.evalStatusCode}} </a> </td>
+              <td> <p style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};"> {{this.evalStatusCode}} </p> </td>
             </tr>
           {{/each}}
         </table>
@@ -72,7 +72,7 @@
                   <td> {{lookup .. this}} </td>
                 {{/if}}
               {{/each}}
-              <td> <a style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};" href="{{this.reportUrl}}"> {{this.evalStatusCode}} </a> </td>
+              <td> <p style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};"> {{this.evalStatusCode}} </p> </td>
             </tr>
           {{/each}}
         </table>
@@ -92,7 +92,7 @@
                   <td> {{lookup .. this}} </td>
                 {{/if}}
               {{/each}}
-              <td> <a style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};" href="{{this.reportUrl}}"> {{this.evalStatusCode}} </a> </td>
+              <td> <p style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};"> {{this.evalStatusCode}} </p> </td>
             </tr>
           {{/each}}
         </table>
@@ -112,7 +112,7 @@
                   <td> {{lookup .. this}} </td>
                 {{/if}}
               {{/each}}
-              <td> <a style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};" href="{{this.reportUrl}}"> {{this.evalStatusCode}} </a> </td>
+              <td> <p style="background-color: {{this.reportColor}}; border-left-color: {{this.reportLineColor}};"> {{this.evalStatusCode}} </p> </td>
             </tr>
           {{/each}}
         </table>


### PR DESCRIPTION
## Ticket
[Evaluation Report Updates](https://github.com/US-EPA-CAMD/easey-ui/issues/5959)

## Changes

- Remove the link associated with the "Evaluation Status Code"
- Remove  Monitoring Plan lat/long info from the email
