### PR TITLE
feat:Add hierarchy for QA evaluations

### DIFF
--- a/src/evaluation/evaluation.service.spec.ts
+++ b/src/evaluation/evaluation.service.spec.ts
@@ -49,6 +49,25 @@ describe('-- Evaluation Service --', () => {
           unitid: 'mockName',
         },
       ]),
+      getRepository: jest.fn().mockImplementation(() => {
+        return {
+          createQueryBuilder: jest.fn().mockImplementation(() => {
+            return {
+              select: jest.fn().mockImplementation(() => {
+                return {
+                  where: jest.fn().mockImplementation(() => {
+                    return {
+                      orderBy: jest.fn().mockImplementation(() => {
+                        return { getRawMany: jest.fn().mockReturnValue(dtoItem.testSumIds) };
+                      }),
+                    };
+                  }),
+                };
+              }),
+            };
+          }),
+        };
+      }),
 
       findOneBy: jest.fn().mockImplementation((val) => {
         switch (val.name) {

--- a/src/evaluation/evaluation.service.spec.ts
+++ b/src/evaluation/evaluation.service.spec.ts
@@ -53,14 +53,10 @@ describe('-- Evaluation Service --', () => {
         return {
           createQueryBuilder: jest.fn().mockImplementation(() => {
             return {
-              select: jest.fn().mockImplementation(() => {
+              where: jest.fn().mockImplementation(() => {
                 return {
-                  where: jest.fn().mockImplementation(() => {
-                    return {
-                      orderBy: jest.fn().mockImplementation(() => {
-                        return { getRawMany: jest.fn().mockReturnValue(dtoItem.testSumIds) };
-                      }),
-                    };
+                  orderBy: jest.fn().mockImplementation(() => {
+                    return { getMany: jest.fn().mockReturnValue([{},{}]) };
                   }),
                 };
               }),

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -76,23 +76,18 @@ export class EvaluationService {
         await this.returnManager().save(mp);
       }
 
-      const testSumIdsOrderdList = await this.returnManager()
+      const testSumsOrderedList = await this.returnManager()
         .getRepository(TestSummary)
         .createQueryBuilder('ts')
-        .select(['ts.test_sum_id'])
         .where({ testSumIdentifier: In(item.testSumIds) })
         .orderBy(
           `(case when ts.test_type_cd='RATA' then 1 when ts.test_type_cd='F2LREF' then 2 when ts.test_type_cd='F2LCHK' then 3 when ts.test_type_cd='FFACC' then 4 when ts.test_type_cd='FFACCTT' then 4 when ts.test_type_cd='PEI' then 4 when ts.test_type_cd='FF2LBAS' then 5 when ts.test_type_cd='FF2LTST' then 6 else null end)`,
         )
-        .getRawMany();
+        .getMany();
 
-      if (testSumIdsOrderdList?.length) {
-        for (const testSummary of testSumIdsOrderdList) {
-          const ts = await this.returnManager().findOneBy(TestSummary, {
-            testSumIdentifier: testSummary.test_sum_id,
-          });
-
-          ts.evalStatusCode = 'INQ';
+      if (testSumsOrderedList?.length) {
+        for (const testSummary of testSumsOrderedList) {
+          testSummary.evalStatusCode = 'INQ';
           const tsRecord = new Evaluation();
           tsRecord.evaluationSetIdentifier = set_id;
           tsRecord.processCode = 'QA';
@@ -101,9 +96,9 @@ export class EvaluationService {
           } else {
             tsRecord.statusCode = 'PENDING';
           }
-          tsRecord.testSumIdentifier = testSummary.test_sum_id;
+          tsRecord.testSumIdentifier = testSummary.testSumIdentifier;
           tsRecord.submittedOn = currentTime;
-          await this.returnManager().save(ts);
+          await this.returnManager().save(testSummary);
           await this.returnManager().save(tsRecord);
         }
       }

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -1,4 +1,4 @@
-import { EntityManager } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { EvaluationDTO, EvaluationItem } from '../dto/evaluation.dto';
@@ -76,27 +76,36 @@ export class EvaluationService {
         await this.returnManager().save(mp);
       }
 
-      for (const id of item.testSumIds) {
-        const ts = await this.returnManager().findOneBy(TestSummary, {
-          testSumIdentifier: id,
-        });
-        ts.evalStatusCode = 'INQ';
+      const testSumIdsOrderdList = await this.returnManager()
+        .getRepository(TestSummary)
+        .createQueryBuilder('ts')
+        .select(['ts.test_sum_id'])
+        .where({ testSumIdentifier: In(item.testSumIds) })
+        .orderBy(
+          `(case when ts.test_type_cd='RATA' then 1 when ts.test_type_cd='F2LREF' then 2 when ts.test_type_cd='F2LCHK' then 3 when ts.test_type_cd='FFACC' then 4 when ts.test_type_cd='FFACCTT' then 4 when ts.test_type_cd='PEI' then 4 when ts.test_type_cd='FF2LBAS' then 5 when ts.test_type_cd='FF2LTST' then 6 else null end)`,
+        )
+        .getRawMany();
 
-        const tsRecord = new Evaluation();
-        tsRecord.evaluationSetIdentifier = set_id;
-        tsRecord.processCode = 'QA';
+      if (testSumIdsOrderdList?.length) {
+        for (const testSummary of testSumIdsOrderdList) {
+          const ts = await this.returnManager().findOneBy(TestSummary, {
+            testSumIdentifier: testSummary.test_sum_id,
+          });
 
-        if (item.submitMonPlan === false) {
-          tsRecord.statusCode = 'QUEUED';
-        } else {
-          tsRecord.statusCode = 'PENDING';
+          ts.evalStatusCode = 'INQ';
+          const tsRecord = new Evaluation();
+          tsRecord.evaluationSetIdentifier = set_id;
+          tsRecord.processCode = 'QA';
+          if (item.submitMonPlan === false) {
+            tsRecord.statusCode = 'QUEUED';
+          } else {
+            tsRecord.statusCode = 'PENDING';
+          }
+          tsRecord.testSumIdentifier = testSummary.test_sum_id;
+          tsRecord.submittedOn = currentTime;
+          await this.returnManager().save(ts);
+          await this.returnManager().save(tsRecord);
         }
-
-        tsRecord.testSumIdentifier = id;
-        tsRecord.submittedOn = currentTime;
-
-        await this.returnManager().save(ts);
-        await this.returnManager().save(tsRecord);
       }
 
       for (const id of item.qceIds) {


### PR DESCRIPTION
## Ticket
[Add hierarchy for QA evaluations](https://github.com/US-EPA-CAMD/easey-ui/issues/5988)

## Changes

- Querying the given testSumIds and orders them in hierarchical order, then following that order, it loops and changes the evalStatusCode.
