### PR TITLE
Fix/6384 error suppression with location

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "17.4.1",
+    "@us-epa-camd/easey-common": "^17.4.1",
     "axios": "^0.28.0",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,16 +6,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { dbConfig } from '@us-epa-camd/easey-common/config';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { CorsOptionsModule } from '@us-epa-camd/easey-common/cors-options';
-import {
-  DbLookupValidator,
-  IsValidCodesValidator,
-} from '@us-epa-camd/easey-common/validators';
+import { DbLookupValidator } from '@us-epa-camd/easey-common/validators';
 
 import routes from './routes';
 import s3Config from './config/s3.config';
 import appConfig from './config/app.config';
 import matsConfig from './config/mats.config';
 import { TypeOrmConfigService } from './config/typeorm.config';
+import { IsValidLocationsValidator } from './validators/is-valid-locations.validator';
 
 import { BulkFileModule } from './bulk-file/bulk-file.module';
 import { BookmarkModule } from './bookmark/bookmark.module';
@@ -63,6 +61,6 @@ import { CopyOfRecordModule } from './copy-of-record/copy-of-record.module';
     MatsFileUploadModule,
     CopyOfRecordModule,
   ],
-  providers: [DbLookupValidator, IsValidCodesValidator],
+  providers: [DbLookupValidator, IsValidLocationsValidator],
 })
 export class AppModule {}

--- a/src/dto/error-suppressions-payload.dto.ts
+++ b/src/dto/error-suppressions-payload.dto.ts
@@ -10,13 +10,11 @@ import {
   IsString,
   ValidationArguments,
 } from 'class-validator';
-import { FindManyOptions, In } from 'typeorm';
 
 import { CheckCatalogResult } from '../entities/check-catalog-result.entity';
 import { EsMatchDataTypeCode } from '../entities/es-match-data-type-code.entity';
 import { EsMatchTimeTypeCode } from '../entities/es-match-time-type-code.entity';
 import { EsReasonCode } from '../entities/es-reason-code.entity';
-import { MonitorLocation } from '../entities/monitor-location.entity';
 import { Plant } from '../entities/plant.entity';
 import { SeverityCode } from '../entities/severity-code.entity';
 import { IsValidLocations } from '../pipes/is-valid-locations.pipe';

--- a/src/dto/error-suppressions-payload.dto.ts
+++ b/src/dto/error-suppressions-payload.dto.ts
@@ -71,14 +71,14 @@ export class ErrorSuppressionsPayloadDTO {
   @IsOptional()
   @IsValidCodes(
     MonitorLocation,
-    (args: ValidationArguments): FindManyOptions<MonitorLocation> => {
+    (args: ValidationArguments): Array<FindManyOptions<MonitorLocation>> => {
       if (typeof args.value !== 'string') {
         return null;
       }
       const locations = args.value.split(',').map((item) => item.trim());
-      return {
-        where: [
-          {
+      return [
+        {
+          where: {
             unit: {
               plant: {
                 facIdentifier: args.object['facilityId'],
@@ -86,7 +86,9 @@ export class ErrorSuppressionsPayloadDTO {
               name: In(locations),
             },
           },
-          {
+        },
+        {
+          where: {
             stackPipe: {
               plant: {
                 facIdentifier: args.object['facilityId'],
@@ -94,10 +96,8 @@ export class ErrorSuppressionsPayloadDTO {
               name: In(locations),
             },
           },
-        ],
-        relations: ['unit', 'stackPipe'],
-        loadEagerRelations: true,
-      };
+        },
+      ];
     },
     {
       message: (args: ValidationArguments) => {

--- a/src/dto/error-suppressions-payload.dto.ts
+++ b/src/dto/error-suppressions-payload.dto.ts
@@ -1,3 +1,6 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { ErrorMessages } from '@us-epa-camd/easey-common/constants';
+import { IsValidCode, IsValidDate } from '@us-epa-camd/easey-common/pipes';
 import {
   IsBoolean,
   IsDateString,
@@ -7,21 +10,16 @@ import {
   IsString,
   ValidationArguments,
 } from 'class-validator';
-import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import { ErrorMessages } from '@us-epa-camd/easey-common/constants';
-import {
-  IsValidCode,
-  IsValidCodes,
-  IsValidDate,
-} from '@us-epa-camd/easey-common/pipes';
-import { Plant } from '../entities/plant.entity';
-import { EsReasonCode } from '../entities/es-reason-code.entity';
+import { FindManyOptions, In } from 'typeorm';
+
 import { CheckCatalogResult } from '../entities/check-catalog-result.entity';
-import { SeverityCode } from '../entities/severity-code.entity';
 import { EsMatchDataTypeCode } from '../entities/es-match-data-type-code.entity';
 import { EsMatchTimeTypeCode } from '../entities/es-match-time-type-code.entity';
+import { EsReasonCode } from '../entities/es-reason-code.entity';
 import { MonitorLocation } from '../entities/monitor-location.entity';
-import { FindManyOptions, In } from 'typeorm';
+import { Plant } from '../entities/plant.entity';
+import { SeverityCode } from '../entities/severity-code.entity';
+import { IsValidLocations } from '../pipes/is-valid-locations.pipe';
 
 const msgA = `You reported an invalid [property] of [value]`;
 
@@ -69,42 +67,11 @@ export class ErrorSuppressionsPayloadDTO {
 
   @IsString()
   @IsOptional()
-  @IsValidCodes(
-    MonitorLocation,
-    (args: ValidationArguments): Array<FindManyOptions<MonitorLocation>> => {
-      if (typeof args.value !== 'string') {
-        return null;
-      }
-      const locations = args.value.split(',').map((item) => item.trim());
-      return [
-        {
-          where: {
-            unit: {
-              plant: {
-                facIdentifier: args.object['facilityId'],
-              },
-              name: In(locations),
-            },
-          },
-        },
-        {
-          where: {
-            stackPipe: {
-              plant: {
-                facIdentifier: args.object['facilityId'],
-              },
-              name: In(locations),
-            },
-          },
-        },
-      ];
+  @IsValidLocations({
+    message: (args: ValidationArguments) => {
+      return `You have reported invalid locations of [${args.value}] for the facilityId [${args.object['facilityId']}].`;
     },
-    {
-      message: (args: ValidationArguments) => {
-        return `You have reported invalid locations of [${args.value}] for the facilityId [${args.object['facilityId']}].`;
-      },
-    },
-  )
+  })
   locations?: string;
 
   @IsString()

--- a/src/entities/plant.entity.ts
+++ b/src/entities/plant.entity.ts
@@ -116,17 +116,11 @@ export class Plant extends BaseEntity {
   updateDate: string;
 
   @OneToMany(() => Unit, (unit) => unit.plant)
-  @JoinColumn({ name: 'unit_id' })
   units: Unit[];
 
   @OneToMany(() => StackPipe, (stackPipe) => stackPipe.plant)
-  @JoinColumn({ name: 'stack_pipe_id' })
   stackPipes: StackPipe[];
 
-  @OneToMany(
-    () => MonitorPlan,
-    plan => plan.plant,
-  )
+  @OneToMany(() => MonitorPlan, (plan) => plan.plant)
   monitorPlans: MonitorPlan[];
-
 }

--- a/src/entities/plant.entity.ts
+++ b/src/entities/plant.entity.ts
@@ -1,11 +1,4 @@
-import {
-  BaseEntity,
-  Column,
-  Entity,
-  JoinColumn,
-  OneToMany,
-  PrimaryColumn,
-} from 'typeorm';
+import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import { Unit } from './unit.entity';

--- a/src/pipes/is-valid-locations.pipe.ts
+++ b/src/pipes/is-valid-locations.pipe.ts
@@ -1,0 +1,14 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { IsValidLocationsValidator } from '../validators/is-valid-locations.validator';
+
+export function IsValidLocations(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidLocations',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: IsValidLocationsValidator,
+    });
+  };
+}

--- a/src/validators/is-valid-locations.validator.ts
+++ b/src/validators/is-valid-locations.validator.ts
@@ -1,0 +1,51 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+
+import { MonitorLocation } from '../entities/monitor-location.entity';
+
+@Injectable()
+@ValidatorConstraint({ name: 'isValidLocations', async: true })
+export class IsValidLocationsValidator implements ValidatorConstraintInterface {
+  constructor(private readonly entityManager: EntityManager) {}
+
+  async validate(value: string | string[], args: ValidationArguments) {
+    if (value) {
+      if (typeof value === 'string') {
+        if (value.includes(',')) {
+          value = value.split(',');
+        } else if (value.includes('|')) {
+          value = value.split('|');
+        } else {
+          value = [value];
+        }
+      }
+      value = value.filter((v) => v !== '');
+
+      const facId = args.object['facilityId'];
+      const found = await this.entityManager
+        .getRepository(MonitorLocation)
+        .createQueryBuilder('ml')
+        .leftJoin('ml.unit', 'u')
+        .leftJoin('u.plant', 'u_p')
+        .leftJoin('ml.stackPipe', 'sp')
+        .leftJoin('sp.plant', 'sp_p')
+        .where('(u.name IN (:...value) AND u_p.facIdentifier = :facId)', {
+          facId,
+          value,
+        })
+        .orWhere('(sp.name IN (:...value) AND sp_p.facIdentifier = :facId)', {
+          facId,
+          value,
+        })
+        .getMany();
+
+      return found.length === value.length;
+    }
+    return true;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,10 +2310,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@17.4.1":
-  version "17.4.1"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.1/f48111f38d5204b5d7d308a7dffc9c202f0e083e#f48111f38d5204b5d7d308a7dffc9c202f0e083e"
-  integrity sha512-rgU7sceWwUiavS4QDnE4ntLPQJzY8zjK1eT042QJH/UXcHYkE22LQQRW4toU+g4LTknFa3NvvjS3Az52B4vHAA==
+"@us-epa-camd/easey-common@^17.4.1":
+  version "17.5.2"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.5.2/39a3f45e27d8113d43a658a6f53b65b59edc9670#39a3f45e27d8113d43a658a6f53b65b59edc9670"
+  integrity sha512-yMtuqelcAkCZ4GZhrACVsSTPBBAGRGG4tuJh3AupT8gYL3pA3y+S9owegKGuNDr3cmwYabne4H6YLv3YiEC7uQ==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
## Related Issues

- [#6384](https://github.com/US-EPA-CAMD/easey-ui/issues/6384)

## Main Changes

- Created a new `IsValidLocations` pipe that handles validation of a monitoring locations string (e.g. '1, 2, CS01') in particular.
- Removed the `IsValidCodes` provider from `app.module.ts`, since it's no longer used by this repository.

## Steps to Test

- See the test case in the linked issue.