### PR TITLE
Feature/6425 configuration manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nestjs/platform-express": "^10.4.7",
     "@nestjs/swagger": "^8.0.2",
     "@nestjs/typeorm": "^10.0.2",
-    "@us-epa-camd/easey-common": "18.1.0",
+    "@us-epa-camd/easey-common": "18.1.2",
     "axios": "^1.7.7",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.1",

--- a/src/entities/monitor-location.entity.ts
+++ b/src/entities/monitor-location.entity.ts
@@ -3,11 +3,13 @@ import {
   Column,
   Entity,
   JoinColumn,
+  ManyToMany,
   OneToOne,
   PrimaryColumn,
 } from 'typeorm';
 
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+import { MonitorPlan } from './monitor-plan.entity';
 import { StackPipe } from './stack-pipe.entity';
 import { Unit } from './unit.entity';
 
@@ -42,4 +44,7 @@ export class MonitorLocation extends BaseEntity {
   @OneToOne(() => Unit, (o) => o.location, { eager: true })
   @JoinColumn({ name: 'unit_id' })
   unit: Unit;
+
+  @ManyToMany(() => MonitorPlan, (plan) => plan.locations)
+  plans: MonitorPlan[];
 }

--- a/src/entities/monitor-plan.entity.ts
+++ b/src/entities/monitor-plan.entity.ts
@@ -1,6 +1,16 @@
-import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
 
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+import { MonitorLocation } from './monitor-location.entity';
 import { Plant } from './plant.entity';
 
 @Entity({ name: 'camdecmpswks.monitor_plan' })
@@ -72,11 +82,21 @@ export class MonitorPlan extends BaseEntity {
   @Column({ name: 'eval_status_cd' })
   evalStatusCode: string;
 
-  @ManyToOne(
-    () => Plant,
-    o => o.monitorPlans,
-  )
+  @ManyToOne(() => Plant, (o) => o.monitorPlans)
   @JoinColumn({ name: 'fac_id' })
   plant: Plant;
 
+  @ManyToMany(() => MonitorLocation, (location) => location.plans)
+  @JoinTable({
+    name: 'camdecmpswks.monitor_plan_location',
+    joinColumn: {
+      name: 'mon_plan_id',
+      referencedColumnName: 'monPlanIdentifier',
+    },
+    inverseJoinColumn: {
+      name: 'mon_loc_id',
+      referencedColumnName: 'monLocIdentifier',
+    },
+  })
+  locations: MonitorLocation[];
 }

--- a/src/submission/submission.service.spec.ts
+++ b/src/submission/submission.service.spec.ts
@@ -53,45 +53,51 @@ describe('-- Submission Service --', () => {
 
   it('should execute a payload successfully and make the proper calls', async () => {
     const mockInsertion = jest.fn();
+    const mockFind = jest.fn().mockImplementation((val) => {
+      switch (val.name) {
+        case 'MonitorPlan':
+          const mp = new MonitorPlan();
+          mp.facIdentifier = 1;
+          mp.locations = [];
+          return mp;
+        case 'Plant':
+          const p = new Plant();
+          p.facilityName = 'test';
+          p.orisCode = 1;
+          return p;
+        case 'QaSuppData':
+          return new QaSuppData();
+        case 'QaCertEvent':
+          return new QaCertEvent();
+        case 'QaTee':
+          return new QaTee();
+        case 'ReportingPeriod':
+          const rp = new ReportingPeriod();
+          rp.rptPeriodIdentifier = 1;
+          return rp;
+        case 'CheckSession':
+          const cs = new CheckSession();
+          return cs;
+        case 'EmissionEvaluation':
+          return new EmissionEvaluation();
+        case 'MatsBulkFile':
+          return new MatsBulkFile();
+      }
+      return false;
+    });
 
     jest.spyOn(service, 'returnManager').mockReturnValue({
+      countBy: jest.fn().mockResolvedValue(0),
+
       query: jest.fn().mockResolvedValue([
         {
           unitid: 'mockName',
         },
       ]),
 
-      findOneBy: jest.fn().mockImplementation((val) => {
-        switch (val.name) {
-          case 'MonitorPlan':
-            const mp = new MonitorPlan();
-            mp.facIdentifier = 1;
-            return mp;
-          case 'Plant':
-            const p = new Plant();
-            p.facilityName = 'test';
-            p.orisCode = 1;
-            return p;
-          case 'QaSuppData':
-            return new QaSuppData();
-          case 'QaCertEvent':
-            return new QaCertEvent();
-          case 'QaTee':
-            return new QaTee();
-          case 'ReportingPeriod':
-            const rp = new ReportingPeriod();
-            rp.rptPeriodIdentifier = 1;
-            return rp;
-          case 'CheckSession':
-            const cs = new CheckSession();
-            return cs;
-          case 'EmissionEvaluation':
-            return new EmissionEvaluation();
-          case 'MatsBulkFile':
-            return new MatsBulkFile();
-        }
-        return false;
-      }),
+      findOne: mockFind,
+
+      findOneBy: mockFind,
 
       save: mockInsertion,
     } as any as EntityManager);

--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -33,7 +33,7 @@ export class SubmissionService {
   ) {}
 
   private async ensureRelatedInactivePlansSubmitted(monPlanId: string) {
-    const mp = await this.entityManager.findOne(MonitorPlan, {
+    const mp = await this.returnManager().findOne(MonitorPlan, {
       where: { monPlanIdentifier: monPlanId },
       relations: { locations: true },
     });
@@ -47,7 +47,7 @@ export class SubmissionService {
     const isActive = mp.endRPTPeriodIdentifier === null;
 
     const existsUnsubmittedInactive =
-      (await this.entityManager.countBy(MonitorPlan, {
+      (await this.returnManager().countBy(MonitorPlan, {
         facIdentifier: mp.facIdentifier,
         locations: {
           monLocIdentifier: In(mp.locations.map((loc) => loc.monLocIdentifier)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,10 +2373,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@18.1.0":
-  version "18.1.0"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/18.1.0/88df137225e21854f5ecfb6699908a6cc35df5c6#88df137225e21854f5ecfb6699908a6cc35df5c6"
-  integrity sha512-acvM48AZ51RWbpnNWDhjpZGZ1v3NMfA9asKw8AVwt+QmVtCOUGKIU6pZyHIRqgkMctJExjvsCw5kFsMhmr2/ug==
+"@us-epa-camd/easey-common@18.1.2":
+  version "18.1.2"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/18.1.2/f05b2bf028b7e1dc58aea036bd738a67e7411a6d#f05b2bf028b7e1dc58aea036bd738a67e7411a6d"
+  integrity sha512-o0Yuaf/Kaa8pHqfdHJOOX4kYZFN7YGPLKx78YF5bzQvv4ImWrt87n/4CyycMhE48WkETsJYgpP9v4whJXZfugA==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "3.1.1"


### PR DESCRIPTION
## Related Issues

- [#6425](https://github.com/US-EPA-CAMD/easey-ui/issues/6425)

## Main Changes:

- Added a check to the submission queueing process to ensure that all inactive monitoring plans for a facility have been submitted before attempting to submit any active monitoring plans.
  - For now, I kept this as simple as possible: the check is run against all items in the request payload, and if the check fails for any of them, it will fail with an error without queueing anything. In the future, we can consider making this "smarter", e.g. allowing inactive and active plans in a single request and letting the back-end sort them out.
 
## Steps to Test:

1. Use the configuration manager to create a new MP. For my testing, I used ORIS 63259 and created a new Stack/Pipe **CP1** active 11/01/2024, and two new UnitStackConfiguration records **DEPC2-CP1** and **DEPC3-CP1**, both active 11/01/2024.
2. Evaluate the newly active plan (**DEPC2, DEPC3, CP1**) and the newly ended plans (**DEPC2** and **DEPC3**). The new plan will evaluate with critical errors, but that can be ignored.
3. In the _Submit_ module, make sure the "Include Files with Critical Errors" radio input is selected, then search for the **DEPC2, DEPC3, CP1** plan. Select the plan for submittal and confirm. Verify a clear error message is displayed.
4. In the same module, search for and select the **DEPC2** and **DEPC3** plans. Submit the MPs, and confirm a success message is displayed.
5. Repeat step 3, but a success message should now show instead.