### PR TITLE
fix/#6429 No Errors Evaluation Reports that are downloaded are missing the evaluation results section

### DIFF
--- a/src/copy-of-record/copy-of-record.service.ts
+++ b/src/copy-of-record/copy-of-record.service.ts
@@ -230,7 +230,8 @@ export class CopyOfRecordService {
           parseInt(templateType.charAt(0)),
           isTest,
         );
-        if (evalStatusCodes.size == 1 && evalStatusCodes.has('PASS')) {
+        //only 1 detail object in deta.details means the report does not have any errors
+        if (data.details.length === 1) {
           innerContent += this.addEvaluationPassTable();
         }
       } else {


### PR DESCRIPTION
### Related Ticket:

- [#6429](https://github.com/orgs/US-EPA-CAMD/projects/2/views/43?sliceBy%5Bvalue%5D=EvanSun220&pane=issue&itemId=84403526&issue=US-EPA-CAMD%7Ceasey-ui%7C6429)

### Updates:

- Updated logic in CopyOfRecordService.generateCopyOfRecord() to add the evaluation results section for no error evaluation reports to be downloaded.


