### PR TITLE
fix:exclude workspace api from swagger beta env

### DIFF
--- a/src/copy-of-record/copy-of-record.controller.ts
+++ b/src/copy-of-record/copy-of-record.controller.ts
@@ -5,6 +5,7 @@ import { ReportParamsDTO } from '../dto/report-params.dto';
 import type { Response } from 'express';
 import { RoleGuard } from '@us-epa-camd/easey-common/decorators';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -65,6 +66,7 @@ export class CopyOfRecordController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   generatePdfWorkspace(
     @Query() params: ReportParamsDTO,
     @Res({ passthrough: true }) res: Response,

--- a/src/evaluation/evaluation.controller.ts
+++ b/src/evaluation/evaluation.controller.ts
@@ -4,6 +4,7 @@ import { EvaluationService } from './evaluation.service';
 import { RoleGuard, AuditLog } from '@us-epa-camd/easey-common/decorators';
 import { EvaluationDTO } from '../dto/evaluation.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiTags('Evaluation')
@@ -22,6 +23,7 @@ export class EvaluationController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @AuditLog({
     label: 'Creates Evaluation Queue',
     requestBodyOutFields:'*',

--- a/src/mats-file-upload/mats-file-upload.controller.ts
+++ b/src/mats-file-upload/mats-file-upload.controller.ts
@@ -14,6 +14,7 @@ import { RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { ConfigService } from '@nestjs/config';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 const MAX_UPLOAD_SIZE_MB: number = 30;
 
@@ -37,6 +38,7 @@ export class MatsFileUploadController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiBody({
     schema: {
       type: 'object',

--- a/src/qa-cert-event/qa-cert-event.controller.ts
+++ b/src/qa-cert-event/qa-cert-event.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  ApiExcludeEndpointByEnv,
   BadRequestResponse,
   NotFoundResponse,
 } from '../utilities/swagger-decorator.const';
@@ -55,6 +56,7 @@ export class QaCertEventController {
 
   @Put(':id')
   @RoleGuard({ requiredRoles: ['ECMPS Admin'] }, LookupType.MonitorPlan)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: false,
     type: QaCertEventMaintViewDTO,
@@ -78,6 +80,7 @@ export class QaCertEventController {
 
   @Delete(':id')
   @RoleGuard({ requiredRoles: ['ECMPS Admin'] }, LookupType.MonitorPlan)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: false,
     type: SuccessMessageDTO,

--- a/src/qa-test-extension-exemption/qa-test-extension-exemption.controller.ts
+++ b/src/qa-test-extension-exemption/qa-test-extension-exemption.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  ApiExcludeEndpointByEnv,
   BadRequestResponse,
   NotFoundResponse,
 } from '../utilities/swagger-decorator.const';
@@ -51,6 +52,7 @@ export class QaTestExtensionExemptionController {
 
   @Put(':id')
   @RoleGuard({ requiredRoles: ['ECMPS Admin'] }, LookupType.MonitorPlan)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: false,
     type: QaTeeMaintViewDTO,
@@ -74,6 +76,7 @@ export class QaTestExtensionExemptionController {
 
   @Delete(':id')
   @RoleGuard({ requiredRoles: ['ECMPS Admin'] }, LookupType.MonitorPlan)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: false,
     type: SuccessMessageDTO,

--- a/src/qa-test-summary/qa-test-summary.controller.ts
+++ b/src/qa-test-summary/qa-test-summary.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  ApiExcludeEndpointByEnv,
   BadRequestResponse,
   NotFoundResponse,
 } from '../utilities/swagger-decorator.const';
@@ -53,6 +54,7 @@ export class QaTestSummaryController {
 
   @Put(':id')
   @RoleGuard({ requiredRoles: ['ECMPS Admin'] }, LookupType.MonitorPlan)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: false,
     type: QaTestSummaryMaintViewDTO,
@@ -76,6 +78,7 @@ export class QaTestSummaryController {
 
   @Delete(':id')
   @RoleGuard({ requiredRoles: ['ECMPS Admin'] }, LookupType.MonitorPlan)
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: false,
     type: SuccessMessageDTO,

--- a/src/report-workspace/report.controller.ts
+++ b/src/report-workspace/report.controller.ts
@@ -14,6 +14,7 @@ import { AuthGuard } from '@us-epa-camd/easey-common/guards';
 import { ReportDTO } from '../dto/report.dto';
 import { DataSetService } from '../dataset/dataset.service';
 import { ReportParamsDTO } from '../dto/report-params.dto';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiTags('Reports')
@@ -28,6 +29,7 @@ export class ReportWorkspaceController {
     type: ReportDTO,
     description: 'Data retrieved successfully',
   })
+  @ApiExcludeEndpointByEnv()
   @ApiOperation({
     description: 'Retrieves list of workspace reports available.',
   })

--- a/src/report-workspace/report.controller.ts
+++ b/src/report-workspace/report.controller.ts
@@ -42,6 +42,7 @@ export class ReportWorkspaceController {
     type: ReportDTO,
     description: 'Data retrieved successfully',
   })
+  @ApiExcludeEndpointByEnv()
   @ApiOperation({
     description:
       'Retrieves workspace data for various reports based on criteria.',

--- a/src/submission/submission.controller.ts
+++ b/src/submission/submission.controller.ts
@@ -13,6 +13,7 @@ import { ClientTokenGuard } from '@us-epa-camd/easey-common/guards';
 import { SubmissionProcessService } from './submission-process.service';
 import { ProcessParamsDTO } from '../dto/process-params.dto';
 import { SubmissionsLastUpdatedResponseDTO } from '../dto/submission-last-updated.dto';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiTags('Submission')
@@ -44,6 +45,7 @@ export class SubmissionController {
     { bodyParam: 'items.*.monPlanId', requiredRoles: ['Submitter', 'Sponsor', 'Initial Authorizer'] },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @AuditLog({
     label: 'Creates Submission Queue',
     requestBodyOutFields:'*',
@@ -61,6 +63,7 @@ export class SubmissionController {
   @ApiSecurity('ClientId')
   @ApiBearerAuth('ClientToken')
   @UseGuards(ClientTokenGuard)
+  @ApiExcludeEndpointByEnv()
   async process(@Body() params: ProcessParamsDTO): Promise<void> {
     this.processService.processSubmissionSet(params.submissionSetId);
   }


### PR DESCRIPTION
## Ticket
[Exclude camd-services's workspace API from Swagger page](https://github.com/US-EPA-CAMD/easey-ui/issues/6469)

## Changes

- Apply `ApiExcludeEndpointByEnv` decorated in workspace APIs