### PR TITLE
Updated the enabling and disabling of swagger documentation per env

### DIFF
--- a/src/utilities/swagger-decorator.const.ts
+++ b/src/utilities/swagger-decorator.const.ts
@@ -8,9 +8,13 @@ import { applyDecorators } from '@nestjs/common';
 import { getConfigValue } from '@us-epa-camd/easey-common/utilities';
 
 const env = getConfigValue('EASEY_CAMD_SERVICES_ENV', 'local-dev');
-const disable = [
-  "dev", "tst", "test", "develop", "development", "local-dev", "staging"
-].includes(env) ? false : true;
+const enableSwagger = [
+  'local-dev',
+  'dev', 'develop', 'development',
+  'tst','test', 'testing',
+  'staging', 'stage',
+  'perf', 'performance',
+].includes(env);
 
 export const BadRequestResponse = () =>
   ApiBadRequestResponse({
@@ -23,9 +27,9 @@ export const NotFoundResponse = () =>
   });
 
 export function ApiExcludeControllerByEnv() {
-  return applyDecorators(ApiExcludeController(disable));
+  return applyDecorators(ApiExcludeController(!enableSwagger));
 }
 
 export function ApiExcludeEndpointByEnv() {
-  return applyDecorators(ApiExcludeEndpoint(disable));
+  return applyDecorators(ApiExcludeEndpoint(!enableSwagger));
 }


### PR DESCRIPTION
Updated the enabling and disabling of swagger documentation so that full swagger documentation for all endpoints is always available in the following environment: local development, development, testing, staging, and performance.

## Pull Request
