### PR TITLE
fix/6378 EM Submission Access Windows Marked as Delete Should not Display in UI

### DIFF
--- a/src/em-submission-access/em-submission-access-view.repository.ts
+++ b/src/em-submission-access/em-submission-access-view.repository.ts
@@ -86,6 +86,9 @@ export class EmSubmissionAccessViewRepository extends Repository<EmSubmissionAcc
       );
     }
 
+    query.andWhere(
+      `(em.submissionAvailabilityCode != 'DELETE')`
+    );
     return query.getMany();
   }
 }


### PR DESCRIPTION

Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6378

Changes
Updated src\em-submission-access\em-submission-access-view.repository.ts getEmSubmissionAccess query to only search for records without 'DELETE' submissionAvailabilityCode value. 