### PR TITLE
fix(6532): added class-validator to package.json resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "resolutions": {
     "xml2js": "^0.5.0",
-    "wrap-ansi": "^7.0.0"
+    "wrap-ansi": "^7.0.0",
+    "class-validator": "0.14.1"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.105.0",


### PR DESCRIPTION
## Main Changes:

- Added a pinned version of `class-validator` to the "resolutions" field of the `package.json`. There is not currently an issue with this, but this will prevent the version in the repo and in easey-common from falling out of sync.
