### PR TITLE
Fix Critical 2 Error handling in submission process

### DIFF
--- a/src/submission/submission-process.service.spec.ts
+++ b/src/submission/submission-process.service.spec.ts
@@ -91,6 +91,74 @@ describe('SubmissionProcessService', () => {
     jest.clearAllMocks();
   });
 
+  describe('copyToOfficial', () => {
+    it('should copy data when there are no Critical 1 Errors', async () => {
+      const submissionSet = new SubmissionSet();
+      submissionSet.submissionSetIdentifier = 'test-set-id';
+
+      const submissionQueueRecords = [
+        { severityCode: 'NONE' },
+        { severityCode: 'CRIT2' } // Critical 2 Error should still allow copying
+      ];
+
+      const transactions = [
+        { command: 'SQL_COMMAND_1', params: [] },
+        { command: 'SQL_COMMAND_2', params: [] }
+      ];
+
+      const mockTransaction = jest.fn().mockImplementation(async (callback) => {
+        await callback({ query: jest.fn() });
+      });
+
+      jest.spyOn(entityManager, 'find').mockResolvedValueOnce(submissionQueueRecords);
+      jest.spyOn(entityManager, 'transaction').mockImplementation(mockTransaction);
+
+      await service.copyToOfficial(submissionSet, transactions);
+
+      expect(entityManager.find).toHaveBeenCalledWith(SubmissionQueue, {
+        where: { submissionSetIdentifier: 'test-set-id' }
+      });
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
+
+    it('should not copy data when there are Critical 1 Errors', async () => {
+      const submissionSet = new SubmissionSet();
+      submissionSet.submissionSetIdentifier = 'test-set-id';
+
+      const submissionQueueRecords = [
+        { severityCode: 'NONE' },
+        { severityCode: 'CRIT1' } // Critical 1 Error should prevent copying
+      ];
+
+      const transactions = [
+        { command: 'SQL_COMMAND_1', params: [] },
+        { command: 'SQL_COMMAND_2', params: [] }
+      ];
+
+      // Mock the find method to return records with a Critical 1 Error
+      jest.spyOn(entityManager, 'find').mockResolvedValueOnce(submissionQueueRecords);
+
+      // Mock the transaction method
+      jest.spyOn(entityManager, 'transaction');
+
+      // Mock the logger to avoid test issues
+      jest.spyOn(logger, 'log').mockImplementation(() => {});
+
+      await service.copyToOfficial(submissionSet, transactions);
+
+      // Verify that find was called with the correct parameters
+      expect(entityManager.find).toHaveBeenCalledWith(SubmissionQueue, {
+        where: { submissionSetIdentifier: 'test-set-id' }
+      });
+
+      // Verify that transaction was not called (because of Critical 1 Errors)
+      expect(entityManager.transaction).not.toHaveBeenCalled();
+
+      // Note: We're not testing the log message as it's an implementation detail
+      // The important behavior is that the transaction is not called when there are Critical 1 Errors
+    });
+  });
+
   describe('processSubmissionSet', () => {
     it('should process a submission set successfully', async () => {
       const setId = 'test-set-id';
@@ -98,7 +166,9 @@ describe('SubmissionProcessService', () => {
       submissionSet.submissionSetIdentifier = setId;
       submissionSet.hasCritErrors = false;
 
-      const submissionSetRecords = [new SubmissionQueue()];
+      const submissionSetRecords = [
+        { statusCode: 'QUEUED', severityCode: 'NONE' }
+      ];
 
       jest.spyOn(entityManager, 'findOne').mockResolvedValueOnce(submissionSet);
       jest.spyOn(entityManager, 'find').mockResolvedValueOnce(submissionSetRecords);
@@ -144,11 +214,79 @@ describe('SubmissionProcessService', () => {
       );
     });
 
+    it('should set status to CRITERR when there are Critical 1 Errors', async () => {
+      const setId = 'test-set-id';
+      const submissionSet = new SubmissionSet();
+      submissionSet.submissionSetIdentifier = setId;
+
+      const submissionSetRecords = [
+        { statusCode: 'QUEUED', severityCode: 'CRIT1' }
+      ];
+
+      jest.spyOn(entityManager, 'findOne').mockResolvedValueOnce(submissionSet);
+      jest.spyOn(entityManager, 'find').mockResolvedValueOnce(submissionSetRecords);
+      jest.spyOn(service['submissionSetHelper'], 'updateSubmissionSetStatus').mockResolvedValue();
+      jest.spyOn(service['submissionSetHelper'], 'setRecordStatusCode').mockResolvedValue();
+      jest.spyOn(fsPromises, 'rm').mockResolvedValue();
+      jest.spyOn(fs, 'mkdirSync').mockImplementation(() => 'mock-directory-path');
+      jest.spyOn(service['transactionService'], 'buildTransactions').mockResolvedValue([]);
+      jest.spyOn(service['documentService'], 'buildDocumentsAndWriteToFile').mockResolvedValue([]);
+      jest.spyOn(service['documentService'], 'sendForSigning').mockResolvedValue();
+      jest.spyOn(service['submissionEmailService'], 'collectFeedbackReportDataForEmail').mockResolvedValue([]);
+      jest.spyOn(service, 'copyToOfficial').mockResolvedValue();
+
+      await service.processSubmissionSet(setId);
+
+      // Verify that setRecordStatusCode was called with 'CRITERR' for Critical 1 Errors
+      expect(service['submissionSetHelper'].setRecordStatusCode).toHaveBeenCalledWith(
+        submissionSet,
+        expect.any(Array),
+        'COMPLETE',
+        '',
+        'CRITERR'
+      );
+    });
+
+    it('should set status to UPDATED when there are Critical 2 Errors but no Critical 1 Errors', async () => {
+      const setId = 'test-set-id';
+      const submissionSet = new SubmissionSet();
+      submissionSet.submissionSetIdentifier = setId;
+
+      const submissionSetRecords = [
+        { statusCode: 'QUEUED', severityCode: 'CRIT2' }
+      ];
+
+      jest.spyOn(entityManager, 'findOne').mockResolvedValueOnce(submissionSet);
+      jest.spyOn(entityManager, 'find').mockResolvedValueOnce(submissionSetRecords);
+      jest.spyOn(service['submissionSetHelper'], 'updateSubmissionSetStatus').mockResolvedValue();
+      jest.spyOn(service['submissionSetHelper'], 'setRecordStatusCode').mockResolvedValue();
+      jest.spyOn(fsPromises, 'rm').mockResolvedValue();
+      jest.spyOn(fs, 'mkdirSync').mockImplementation(() => 'mock-directory-path');
+      jest.spyOn(service['transactionService'], 'buildTransactions').mockResolvedValue([]);
+      jest.spyOn(service['documentService'], 'buildDocumentsAndWriteToFile').mockResolvedValue([]);
+      jest.spyOn(service['documentService'], 'sendForSigning').mockResolvedValue();
+      jest.spyOn(service['submissionEmailService'], 'collectFeedbackReportDataForEmail').mockResolvedValue([]);
+      jest.spyOn(service, 'copyToOfficial').mockResolvedValue();
+
+      await service.processSubmissionSet(setId);
+
+      // Verify that setRecordStatusCode was called with 'UPDATED' for Critical 2 Errors
+      expect(service['submissionSetHelper'].setRecordStatusCode).toHaveBeenCalledWith(
+        submissionSet,
+        expect.any(Array),
+        'COMPLETE',
+        '',
+        'UPDATED'
+      );
+    });
+
     it('should handle errors and call error handler properly', async () => {
       const setId = 'test-set-id';
       const submissionSet = new SubmissionSet();
       submissionSet.submissionSetIdentifier = setId;
-      const submissionSetRecords = [new SubmissionQueue()];
+      const submissionSetRecords = [
+        { statusCode: 'QUEUED', severityCode: 'NONE' }
+      ];
       const error = new Error('Test Error');
       const stages: { action: string; dateTime: string }[] = [];
       stages.push({ action: 'SUBMISSION_LOADED', dateTime: 'N/A' });

--- a/src/submission/submission-process.service.ts
+++ b/src/submission/submission-process.service.ts
@@ -96,25 +96,25 @@ export class SubmissionProcessService {
       this.logger.debug('Sending emails with feedback attachment ...');
       for (const submissionFeedbackEmailData of submissionFeedbackEmailDataList) {
 
-          this.logger.debug('Sending email feedback...');
+        this.logger.debug('Sending email feedback...');
 
-          // Attempt to send an email. If sending an email for this particular file type fails,
-          // log the error and continue attempting to send emails for the others
-          try {
-            await this.mailEvalService.sendEmailWithRetry(
-              submissionFeedbackEmailData.toEmail,
-              submissionFeedbackEmailData.ccEmail,
-              submissionFeedbackEmailData.fromEmail,
-              submissionFeedbackEmailData.subject,
-              submissionFeedbackEmailData.emailTemplate,
-              submissionFeedbackEmailData.templateContext,
-              1,
-              submissionFeedbackEmailData.feedbackAttachmentDocuments,
-            );
-          } catch (e) {
-            this.logger.error('Error attempting to send feedback email : ' +  {processCode : submissionFeedbackEmailData.processCode}, e.stack, 'SubmissionProcessService');
-            await this.errorHandlerService.handleSubmissionProcessingError(submissionFeedbackEmailData.submissionSet, submissionFeedbackEmailData.submissionQueueRecords, submissionStages, e);
-          }
+        // Attempt to send an email. If sending an email for this particular file type fails,
+        // log the error and continue attempting to send emails for the others
+        try {
+          await this.mailEvalService.sendEmailWithRetry(
+            submissionFeedbackEmailData.toEmail,
+            submissionFeedbackEmailData.ccEmail,
+            submissionFeedbackEmailData.fromEmail,
+            submissionFeedbackEmailData.subject,
+            submissionFeedbackEmailData.emailTemplate,
+            submissionFeedbackEmailData.templateContext,
+            1,
+            submissionFeedbackEmailData.feedbackAttachmentDocuments,
+          );
+        } catch (e) {
+          this.logger.error('Error attempting to send feedback email : ' +  {processCode : submissionFeedbackEmailData.processCode}, e.stack, 'SubmissionProcessService');
+          await this.errorHandlerService.handleSubmissionProcessingError(submissionFeedbackEmailData.submissionSet, submissionFeedbackEmailData.submissionQueueRecords, submissionStages, e);
+        }
       }
 
       submissionStages.push({ action: 'FEEDBACK_EMAILS_SENT', dateTime: await this.submissionSetHelper.getFormattedDateTime()  || 'N/A' });
@@ -123,7 +123,21 @@ export class SubmissionProcessService {
       // ONLY if there are no submission queue records that have Errors
       const nonErrorRecords = submissionQueueRecords.filter(record => record.statusCode !== 'ERROR');
       const errorRecords = submissionQueueRecords.filter(record => record.statusCode === 'ERROR');
-      await this.submissionSetHelper.setRecordStatusCode(set, nonErrorRecords, 'COMPLETE', '', set.hasCritErrors ? 'CRITERR' : 'UPDATED');
+
+      // Check if any records have Critical 1 Errors
+      const hasCrit1Errors = submissionQueueRecords.some(record =>
+        record.severityCode === 'CRIT1'
+      );
+
+      // Set status to 'CRITERR' only if there are Critical 1 Errors
+      await this.submissionSetHelper.setRecordStatusCode(
+        set,
+        nonErrorRecords,
+        'COMPLETE',
+        '',
+        hasCrit1Errors ? 'CRITERR' : 'UPDATED'
+      );
+
       if (errorRecords.length <= 0) {
         await this.submissionSetHelper.updateSubmissionSetStatus(set, 'COMPLETE');
       }
@@ -144,13 +158,25 @@ export class SubmissionProcessService {
     transactions: any[],
   ) {
     try {
+      // Get all submission queue records for this submission set
+      const submissionQueueRecords = await this.entityManager.find(SubmissionQueue, {
+        where: { submissionSetIdentifier: set.submissionSetIdentifier }
+      });
 
-      if (!set.hasCritErrors) {
+      // Check if any records have Critical 1 Errors
+      const hasCrit1Errors = submissionQueueRecords.some(record =>
+        record.severityCode === 'CRIT1'
+      );
+
+      // Only prevent copying if there are Critical 1 Errors
+      if (!hasCrit1Errors) {
         await this.entityManager.transaction(async (manager) => {
           for (const trans of transactions) {
             await manager.query(trans.command, trans.params);
           }
         });
+      } else {
+        this.logger.log(`Skipping copyToOfficial due to Critical 1 Errors in submission set: ${set.submissionSetIdentifier}`);
       }
     } catch (e) {
       this.logger.error('Error during copyToOfficial processing.', e.stack, 'SubmissionProcessService');


### PR DESCRIPTION
### Changes Made:
Fix Critical 2 Error handling in submission process
Backend:
- Modified file to only prevent copying to Official when Critical 1 Errors are present
- Updated status code logic to set 'CRITERR' only for Critical 1 Errors and 'UPDATED' for Critical 2 Errors
- Updated tests to verify correct behavior for both error types
### Related To: (https://github.com/US-EPA-CAMD/easey-ecmps-ui/pull/1555)

