### PR TITLE
feature/#6617 EM Submission Access Windows Marked as Delete Should Display in UI

### DIFF
--- a/src/em-submission-access/em-submission-access-view.repository.ts
+++ b/src/em-submission-access/em-submission-access-view.repository.ts
@@ -93,10 +93,7 @@ export class EmSubmissionAccessViewRepository extends Repository<EmSubmissionAcc
     }
     
     // status 'NO WINDOW' will be handled seperately
-
-    query.andWhere(
-      `(em.submissionAvailabilityCode != 'DELETE')`
-    );
+    
     return query.getMany();
   }
 }


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6617](https://github.com/orgs/US-EPA-CAMD/projects/2/views/6?filterQuery=6617&pane=issue&itemId=100861938&issue=US-EPA-CAMD%7Ceasey-ui%7C6617)

### **Updates:**

- Removed the logic that block the DELETE records from displaying on EM Submission Access page