### PR TITLE
To update Crit2 errors required the "Include Files with Critical Errors" option to be copied to Official (#6629)

### DIFF
--- a/src/dto/submission-queue.dto.ts
+++ b/src/dto/submission-queue.dto.ts
@@ -1,13 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsString } from 'class-validator';
+import { IsString } from 'class-validator';
 import { EvaluationDTO } from './evaluation.dto';
 
 export class SubmissionQueueDTO extends EvaluationDTO {
   @ApiProperty()
   @IsString()
   activityId: string;
-
-  @ApiProperty()
-  @IsBoolean()
-  hasCritErrors: boolean;
 }

--- a/src/submission/submission.service.spec.ts
+++ b/src/submission/submission.service.spec.ts
@@ -33,7 +33,7 @@ payloadDto.items = [dtoItem, dtoItem];
 payloadDto.userId = 'testUser';
 payloadDto.userEmail = 'test@example.com';
 payloadDto.activityId = 'activity123';
-payloadDto.hasCritErrors = false;
+//payloadDto.hasCritErrors = false;
 
 describe('-- Submission Service --', () => {
   let service: SubmissionService;

--- a/src/submission/submission.service.spec.ts
+++ b/src/submission/submission.service.spec.ts
@@ -18,6 +18,9 @@ import { EmissionsLastUpdatedMap } from '../maps/emissions-last-updated.map';
 import { CheckSession } from '../entities/check-session.entity';
 import { ErrorHandlerService } from './error-handler.service';
 import { SubmissionSetHelperService } from './submission-set-helper.service';
+import { SeverityCode } from '../entities/severity-code.entity';
+import { SubmissionQueue } from '../entities/submission-queue.entity';
+import { SubmissionSet } from '../entities/submission-set.entity';
 
 const dtoItem = new EvaluationItem();
 dtoItem.monPlanId = 'mock';
@@ -33,7 +36,6 @@ payloadDto.items = [dtoItem, dtoItem];
 payloadDto.userId = 'testUser';
 payloadDto.userEmail = 'test@example.com';
 payloadDto.activityId = 'activity123';
-//payloadDto.hasCritErrors = false;
 
 describe('-- Submission Service --', () => {
   let service: SubmissionService;
@@ -98,6 +100,17 @@ describe('-- Submission Service --', () => {
       getOne: jest.fn().mockResolvedValue(new CheckSession()),
     };
 
+    // Mock for findOne method
+    const findOneMock = jest.fn().mockImplementation((entity, criteria) => {
+      if (entity === MonitorPlan) {
+        const mp = new MonitorPlan();
+        mp.facIdentifier = 1;
+        mp.locations = []; // Add mock locations
+        return mp;
+      }
+      return null;
+    });
+
     const transactionMock = jest.fn(async (fn) => {
       return fn(entityManagerMock);
     });
@@ -105,9 +118,12 @@ describe('-- Submission Service --', () => {
     entityManagerMock = {
       query: queryMock,
       findOneBy: findOneByMock,
+      findOne: findOneMock, // Add findOne mock
+      find: jest.fn().mockResolvedValue([]), // Add find mock with empty array by default
       save: saveMock,
       transaction: transactionMock,
       createQueryBuilder: jest.fn().mockReturnValue(createQueryBuilderMock),
+      countBy: jest.fn().mockResolvedValue(0), // Mock countBy to return 0 (meaning - no unsubmitted inactive plans)
     };
 
     const module = await Test.createTestingModule({
@@ -137,9 +153,56 @@ describe('-- Submission Service --', () => {
     }).compile();
 
     service = module.get(SubmissionService);
+
+    // Mock the returnManager method to return entityManagerMock
+    service.returnManager = jest.fn().mockReturnValue(entityManagerMock);
   });
 
   it('should be defined', async () => {
     expect(service).toBeDefined();
+  });
+
+    // Test for checking critical errors based on evalStatusCode
+  it('should check for critical errors based on evalStatusCode', async () => {
+    // Mock the find method to return submission queue records
+    const mockSubmissionQueueRecords = [
+      { submissionSetIdentifier: 'test-set-id', severityCode: 'CRIT1' },
+      { submissionSetIdentifier: 'test-set-id', severityCode: 'CRIT2' }
+    ];
+    entityManagerMock.find = jest.fn().mockResolvedValue(mockSubmissionQueueRecords);
+
+    // Mock the findOneBy method for SeverityCode to return different evalStatusCode values
+    const originalFindOneBy = entityManagerMock.findOneBy;
+    entityManagerMock.findOneBy = jest.fn().mockImplementation((entity, criteria) => {
+      if (entity === SeverityCode) {
+        if (criteria.severityCode === 'CRIT1') {
+          const severityCode = new SeverityCode();
+          severityCode.severityCode = 'CRIT1';
+          severityCode.evalStatusCode = 'ERR';
+          return severityCode;
+        } else if (criteria.severityCode === 'CRIT2') {
+          const severityCode = new SeverityCode();
+          severityCode.severityCode = 'CRIT2';
+          severityCode.evalStatusCode = 'INFO';
+          return severityCode;
+        }
+        return null;
+      }
+      return originalFindOneBy(entity, criteria);
+    });
+
+    // Create a test submission set
+    const submissionSet = new SubmissionSet();
+    submissionSet.submissionSetIdentifier = 'test-set-id';
+
+    // Call the private queueRecord method through a transaction
+    await service.queueSubmissionRecords(payloadDto);
+
+    // Verify entityManager was saved and called with a submission set that has hasCritErrors = true
+    // This is because one of the records has a severity code with evalStatusCode = 'ERR'
+    expect(entityManagerMock.save).toHaveBeenCalledWith(
+      SubmissionSet,
+      expect.objectContaining({ hasCritErrors: true })
+    );
   });
 });

--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -78,7 +78,7 @@ export class SubmissionService {
     userId: string,
     userEmail: string,
     activityId: string,
-    hasCritErrors: boolean,
+    //hasCritErrors: boolean,
     evaluationItem: EvaluationItem,
     entityManager: EntityManager,
     queueingStages: { action: string; dateTime: string }[],
@@ -86,6 +86,7 @@ export class SubmissionService {
 
     const submissionSet = new SubmissionSet();
     let currentSubmissionQueue: SubmissionQueue | null = null;
+    let hasCritErrors = false;
 
     try {
       const currentTime = new Date();
@@ -93,7 +94,7 @@ export class SubmissionService {
 
       this.logger.log(`Queueing record. setId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, UserId: ${userId || 'N/A'}`,);
 
-      submissionSet.hasCritErrors = hasCritErrors;
+      //submissionSet.hasCritErrors = hasCritErrors;
       submissionSet.activityId = activityId;
       submissionSet.submissionSetIdentifier = setId;
       submissionSet.monPlanIdentifier = evaluationItem.monPlanId;
@@ -355,9 +356,24 @@ export class SubmissionService {
         }
       }
 
-      this.logger.log(`Successfully queued record. SetId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}`,);
+      //this.logger.log(`Successfully queued record. SetId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}`,);
 
-    } catch (e) {
+      // Determine if there are any critical errors (CRIT1) in the submission
+      // Get all submission queue records for this set
+      const submissionQueueRecords = await entityManager.find(SubmissionQueue, {
+        where: { submissionSetIdentifier: setId },
+      });
+
+      // Check if any record has a severity code of CRIT1
+      const hasCrit1Error = submissionQueueRecords.some(record => record.severityCode === 'CRIT1');
+
+      // Set the hasCritErrors flag based on CRIT1 errors only
+      submissionSet.hasCritErrors = hasCrit1Error;
+      await entityManager.save(SubmissionSet, submissionSet);
+
+      this.logger.log(`Successfully queued record. SetId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, hasCritErrors: ${hasCrit1Error}`,);
+
+      } catch (e) {
       this.logger.error(`Failed to queue record. MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, Error: ${e.message}`, e.stack,);
       this.logger.error(`Aborting transaction`);
 
@@ -390,7 +406,7 @@ export class SubmissionService {
     const userId = submissionQueueParam.userId;
     const userEmail = submissionQueueParam.userEmail;
     const activityId = submissionQueueParam.activityId;
-    const hasCritErrors = submissionQueueParam.hasCritErrors;
+    //const hasCritErrors = submissionQueueParam.hasCritErrors;
     const evaluationItems = submissionQueueParam.items;
 
     try {
@@ -402,7 +418,7 @@ export class SubmissionService {
             userId,
             userEmail,
             activityId,
-            hasCritErrors,
+            //hasCritErrors,
             evaluationItem,
             transactionalEntityManager, // Pass the transactional EntityManager
             queueingStages,

--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -94,7 +94,6 @@ export class SubmissionService {
 
       this.logger.log(`Queueing record. setId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, UserId: ${userId || 'N/A'}`,);
 
-      //submissionSet.hasCritErrors = hasCritErrors;
       submissionSet.activityId = activityId;
       submissionSet.submissionSetIdentifier = setId;
       submissionSet.monPlanIdentifier = evaluationItem.monPlanId;
@@ -356,8 +355,6 @@ export class SubmissionService {
         }
       }
 
-      //this.logger.log(`Successfully queued record. SetId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}`,);
-
       // Determine if there are any critical errors (CRIT1) in the submission
       // Get all submission queue records for this set
       const submissionQueueRecords = await entityManager.find(SubmissionQueue, {
@@ -406,7 +403,6 @@ export class SubmissionService {
     const userId = submissionQueueParam.userId;
     const userEmail = submissionQueueParam.userEmail;
     const activityId = submissionQueueParam.activityId;
-    //const hasCritErrors = submissionQueueParam.hasCritErrors;
     const evaluationItems = submissionQueueParam.items;
 
     try {

--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -18,6 +18,7 @@ import { QaCertEvent } from '../entities/qa-cert-event.entity';
 import { QaSuppData } from '../entities/qa-supp.entity';
 import { QaTee } from '../entities/qa-tee.entity';
 import { ReportingPeriod } from '../entities/reporting-period.entity';
+import { SeverityCode } from '../entities/severity-code.entity';
 import { SubmissionQueue } from '../entities/submission-queue.entity';
 import { SubmissionSet } from '../entities/submission-set.entity';
 import { CombinedSubmissionsMap } from '../maps/combined-submissions.map';
@@ -78,7 +79,6 @@ export class SubmissionService {
     userId: string,
     userEmail: string,
     activityId: string,
-    //hasCritErrors: boolean,
     evaluationItem: EvaluationItem,
     entityManager: EntityManager,
     queueingStages: { action: string; dateTime: string }[],
@@ -86,7 +86,7 @@ export class SubmissionService {
 
     const submissionSet = new SubmissionSet();
     let currentSubmissionQueue: SubmissionQueue | null = null;
-    let hasCritErrors = false;
+    let hasCriticalErrors = false;
 
     try {
       const currentTime = new Date();
@@ -355,20 +355,33 @@ export class SubmissionService {
         }
       }
 
-      // Determine if there are any critical errors (CRIT1) in the submission
+      // Determine if there are any critical errors based on evalStatusCode in the submission
       // Get all submission queue records for this set
       const submissionQueueRecords = await entityManager.find(SubmissionQueue, {
         where: { submissionSetIdentifier: setId },
       });
 
-      // Check if any record has a severity code of CRIT1
-      const hasCrit1Error = submissionQueueRecords.some(record => record.severityCode === 'CRIT1');
+      // Check if any record has a severity code with evalStatusCode of ERR
+      submissionSet.hasCritErrors = false;
 
-      // Set the hasCritErrors flag based on CRIT1 errors only
-      submissionSet.hasCritErrors = hasCrit1Error;
-      await entityManager.save(SubmissionSet, submissionSet);
+      // Iterate through each record to check its severity code's evalStatusCode
+      for (const record of submissionQueueRecords) {
+        const severity = await entityManager.findOneBy(SeverityCode, {
+          severityCode: record.severityCode,
+        });
 
-      this.logger.log(`Successfully queued record. SetId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, hasCritErrors: ${hasCrit1Error}`,);
+        if (severity?.evalStatusCode === 'ERR') {
+          submissionSet.hasCritErrors = true;
+          break;
+        }
+      }
+
+      // Only save if there are critical errors
+      if (submissionSet.hasCritErrors) {
+        await entityManager.save(SubmissionSet, submissionSet);
+      }
+
+      this.logger.log(`Successfully queued record. SetId: ${setId}, MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, hasCritErrors: ${submissionSet.hasCritErrors}`,);
 
       } catch (e) {
       this.logger.error(`Failed to queue record. MonPlanId: ${evaluationItem?.monPlanId || 'N/A'}, Error: ${e.message}`, e.stack,);
@@ -406,7 +419,6 @@ export class SubmissionService {
     const evaluationItems = submissionQueueParam.items;
 
     try {
-
       //wrap everything in a transaction to ensure that all records are queued or none are queued
       await this.entityManager.transaction(async (transactionalEntityManager) => {
         for (const evaluationItem of evaluationItems) {
@@ -414,7 +426,6 @@ export class SubmissionService {
             userId,
             userEmail,
             activityId,
-            //hasCritErrors,
             evaluationItem,
             transactionalEntityManager, // Pass the transactional EntityManager
             queueingStages,


### PR DESCRIPTION
### Changes Made: 
- Updated severity_code table to set eval_status_cd to 'INFO' for CRIT2 and CRIT3 codes
- Removed hasCritErrors flag from UI payload in EvaluateAndSubmit.js
- Removed hasCritErrors property from SubmissionQueueDTO
- Implemented new logic in CAMD Services to determine hasCritErrors based only on CRIT1 severity codes

### Testing:
- Verified that files with Crit2 errors can be submitted without selecting "Include Files with Critical Errors"
- Confirmed that Crit2 files are properly loaded into the database
- Validated that data is preserved when reverting Crit2 files
