### PR TITLE
Refine List of Submissions Report (CAT) 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,7 @@ import { SubmissionModule } from './submission/submission.module';
 import { MatsFileUploadModule } from './mats-file-upload/mats-file-upload.module';
 import { CopyOfRecordModule } from './copy-of-record/copy-of-record.module';
 import { SubmissionReportModule } from './submission-report/submission-report.module';
+import { TestTypeCode } from './test-type-code/test-type-code.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { SubmissionReportModule } from './submission-report/submission-report.mo
     MailModule,
     ErrorSuppressionsModule,
     SubmissionReportModule,
+    TestTypeCode,
     EvaluationModule,
     AdminModule,
     QaTestExtensionExemptionModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,7 +39,7 @@ import { SubmissionModule } from './submission/submission.module';
 import { MatsFileUploadModule } from './mats-file-upload/mats-file-upload.module';
 import { CopyOfRecordModule } from './copy-of-record/copy-of-record.module';
 import { SubmissionReportModule } from './submission-report/submission-report.module';
-import { TestTypeCode } from './test-type-code/test-type-code.module';
+import { TestTypeCodeModule } from './test-type-code/test-type-code.module';
 import { HealthModule } from '@us-epa-camd/easey-common/health/health.module';
 
 @Module({
@@ -63,7 +63,7 @@ import { HealthModule } from '@us-epa-camd/easey-common/health/health.module';
     MailModule,
     ErrorSuppressionsModule,
     SubmissionReportModule,
-    TestTypeCode,
+    TestTypeCodeModule,
     EvaluationModule,
     AdminModule,
     QaTestExtensionExemptionModule,

--- a/src/dto/submission-report-params.dto.ts
+++ b/src/dto/submission-report-params.dto.ts
@@ -1,10 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 import {
   IsOptional,
   IsString,
   ValidationArguments,
-  IsEnum
+  IsEnum,
+  IsArray
 } from 'class-validator';
 
 import { IsValidCode, IsInRange } from '@us-epa-camd/easey-common/pipes';
@@ -16,6 +17,7 @@ import { FindOneOptions } from 'typeorm/find-options/FindOneOptions';
 import { Plant } from '../entities/plant.entity';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { SubmissionTypeCodes } from '../enums/submission-code.enum';
+import { QADataType } from '../enums/qa-data-type.enum';
 const msgA =
   'The [property] is not valid refer to the list of available [property]s for valid values';
 const msgB = `Ensure [property] are in the following formats Date Range - YYYY-mm-dd /Hour Range- YYYY-mm-dd hh/Quarter Range – YYYY Q1/Q2/Q3/Q4`;
@@ -104,4 +106,24 @@ submissionFrom?: string;
     },
 })
 submissionTo?: string;
+
+@IsOptional()
+@ApiProperty({ enum: QADataType })
+@IsString()
+@IsEnum(QADataType, {
+    message: () => {
+      return `The status must have a valid QA Data Type`;
+    },
+  })
+qaDataType?: string;
+
+@IsOptional()
+@IsString()
+testType?: string;
+
+@IsOptional()
+@ApiProperty({ isArray: true })
+@Transform(({ value }) => value.split('|').map((item) => item.trim()))
+@IsArray()
+locations?: string[];
 }

--- a/src/dto/submission-report.dto.ts
+++ b/src/dto/submission-report.dto.ts
@@ -23,7 +23,7 @@ export class SubmissionReportDTO {
 
   @ApiProperty()
   @IsString()
-  reportingPeriodAbbreviation: string;
+  identifyingInformation: string;
 
   @ApiProperty()
   @IsString()

--- a/src/dto/submission-report.dto.ts
+++ b/src/dto/submission-report.dto.ts
@@ -59,25 +59,5 @@ export class SubmissionReportDTO {
 
   @ApiProperty()
   @IsString()
-  criticalErrLevelOne: string;
-
-  @ApiProperty()
-  @IsString()
-  criticalErrLevelTwo: string;
-
-  @ApiProperty()
-  @IsString()
-  nonCritical: string;
-
-  @ApiProperty()
-  @IsString()
-  infoMessage: string;
-
-  @ApiProperty()
-  @IsString()
-  adminOverride: string;
-
-  @ApiProperty()
-  @IsString()
   submitter: string;
 }

--- a/src/dto/submission-report.dto.ts
+++ b/src/dto/submission-report.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsDate,
   IsNumber,
   IsString,
 } from 'class-validator';
@@ -39,8 +38,8 @@ export class SubmissionReportDTO {
   submissionId: number;
 
   @ApiProperty()
-  @IsDate()
-  submissionDateTime: Date;
+  @IsString()
+  submissionDateTime: string;
 
   @ApiProperty()
   @IsString()

--- a/src/entities/submission-list-vw.entity.ts
+++ b/src/entities/submission-list-vw.entity.ts
@@ -88,31 +88,6 @@ export class SubmissionListView extends BaseEntity {
   severityCode: string;
 
   @Column({
-    name: 'severity_critical_1',
-  })
-  criticalErrLevelOne: string;
-
-  @Column({
-    name: 'severity_critical_2',
-  })
-  criticalErrLevelTwo: string;
-
-  @Column({
-    name: 'severity_non_critical',
-  })
-  nonCritical: string;
-
-  @Column({
-    name: 'severity_informational',
-  })
-  infoMessage: string;
-
-  @Column({
-    name: 'severity_administrative_override',
-  })
-  adminOverride: string;
-
-  @Column({
     name: 'submitter',
   })
   submitter: string;

--- a/src/entities/submission-list-vw.entity.ts
+++ b/src/entities/submission-list-vw.entity.ts
@@ -48,7 +48,7 @@ export class SubmissionListView extends BaseEntity {
 
   @Column({
     name: 'queued_time',
-    type: 'date',
+    type: 'timestamp',
   })
   submissionDateTime: Date;
 

--- a/src/entities/submission-list-vw.entity.ts
+++ b/src/entities/submission-list-vw.entity.ts
@@ -35,6 +35,11 @@ export class SubmissionListView extends BaseEntity {
   })
   locations: string;
 
+    @Column({
+    name: 'reporting_period',
+  })
+  reportingPeriod: string;
+  
   @Column({
     name: 'identifying_information',
   })

--- a/src/entities/submission-list-vw.entity.ts
+++ b/src/entities/submission-list-vw.entity.ts
@@ -21,6 +21,16 @@ export class SubmissionListView extends BaseEntity {
   state: string;
 
   @Column({
+    name: 'qa_data_type_cd',
+  })
+  qaDataTypeCode: string;
+
+  @Column({
+    name: 'test_type_cd',
+  })
+  testTypeCode: string;
+
+  @Column({
     name: 'locations',
   })
   locations: string;

--- a/src/entities/submission-list-vw.entity.ts
+++ b/src/entities/submission-list-vw.entity.ts
@@ -36,9 +36,9 @@ export class SubmissionListView extends BaseEntity {
   locations: string;
 
   @Column({
-    name: 'reporting_period',
+    name: 'identifying_information',
   })
-  reportingPeriod: string;
+  identifyingInformation: string;
 
   @Column({
     name: 'reporting_frequency',

--- a/src/enums/qa-data-type.enum.ts
+++ b/src/enums/qa-data-type.enum.ts
@@ -1,0 +1,5 @@
+export enum QADataType {
+  Test,
+  Event,
+  TEE
+}

--- a/src/enums/qa-data-type.enum.ts
+++ b/src/enums/qa-data-type.enum.ts
@@ -1,5 +1,5 @@
 export enum QADataType {
-  Test,
-  Event,
+  QAT,
+  QCE,
   TEE
 }

--- a/src/error-suppressions/error-suppressions.repository.ts
+++ b/src/error-suppressions/error-suppressions.repository.ts
@@ -7,7 +7,7 @@ import { QueryBuilderHelper } from '../utilities/query-builder.helper';
 
 @Injectable()
 export class ErrorSuppressionsRepository extends Repository<EsSpec> {
-  constructor(entityManager: EntityManager) {
+  constructor(entityManager: EntityManager  ) {
     super(EsSpec, entityManager);
   }
 
@@ -82,7 +82,7 @@ export class ErrorSuppressionsRepository extends Repository<EsSpec> {
     }
     if (locations) {
       query.andWhere(
-        `string_to_array(es.locations, ',') && :locations`,
+        `string_to_array(replace(ss.locations, ' ', ''), ',') && :locations::text[]`,
         { locations },
       );
     }

--- a/src/error-suppressions/error-suppressions.repository.ts
+++ b/src/error-suppressions/error-suppressions.repository.ts
@@ -82,7 +82,7 @@ export class ErrorSuppressionsRepository extends Repository<EsSpec> {
     }
     if (locations) {
       query.andWhere(
-        `string_to_array(replace(ss.locations, ' ', ''), ',') && :locations::text[]`,
+        `string_to_array(replace(es.locations, ' ', ''), ',') && :locations::text[]`,
         { locations },
       );
     }

--- a/src/error-suppressions/error-suppressions.repository.ts
+++ b/src/error-suppressions/error-suppressions.repository.ts
@@ -7,7 +7,7 @@ import { QueryBuilderHelper } from '../utilities/query-builder.helper';
 
 @Injectable()
 export class ErrorSuppressionsRepository extends Repository<EsSpec> {
-  constructor(entityManager: EntityManager  ) {
+  constructor(entityManager: EntityManager ) {
     super(EsSpec, entityManager);
   }
 

--- a/src/error-suppressions/error-suppressions.repository.ts
+++ b/src/error-suppressions/error-suppressions.repository.ts
@@ -7,7 +7,7 @@ import { QueryBuilderHelper } from '../utilities/query-builder.helper';
 
 @Injectable()
 export class ErrorSuppressionsRepository extends Repository<EsSpec> {
-  constructor(entityManager: EntityManager ) {
+  constructor(entityManager: EntityManager) {
     super(EsSpec, entityManager);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,18 @@ import {
   applySwagger,
 } from '@us-epa-camd/easey-common/nestjs';
 import { useContainer } from 'class-validator';
+import { ValidationPipe } from '@nestjs/common';
 
 import { AppModule } from './app.module';
 
 export async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+   app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true, // needed to use @Transform to work
+    }),
+  );
 
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
   await applyMiddleware(AppModule, app, true);

--- a/src/maps/submission-list.map.ts
+++ b/src/maps/submission-list.map.ts
@@ -29,11 +29,6 @@ SubmissionReportDTO
         mostRecent :  entity?.mostRecent,
         submissionStatus :  entity?.submissionStatus,
         severityCode :  entity?.severityCode,
-        criticalErrLevelOne :  entity?.criticalErrLevelOne,
-        criticalErrLevelTwo :  entity?.criticalErrLevelTwo,
-        nonCritical :  entity?.nonCritical,
-        infoMessage :  entity?.infoMessage,
-        adminOverride :  entity?.adminOverride,
         submitter :  entity?.submitter
     };
   }

--- a/src/maps/submission-list.map.ts
+++ b/src/maps/submission-list.map.ts
@@ -18,7 +18,7 @@ SubmissionReportDTO
         facilityName :  entity?.facilityName,
         state :  entity?.state,
         locations :  entity?.locations,
-        reportingPeriodAbbreviation :  entity?.reportingPeriod,
+        identifyingInformation :  entity?.identifyingInformation,
         reportingFrequencyCode :  entity?.reportingFrequencyCode,
         submissionTypeCode :  entity?.submissionTypeCode,
         submissionId :  entity?.submissionId,

--- a/src/maps/submission-list.map.ts
+++ b/src/maps/submission-list.map.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BaseMap } from '@us-epa-camd/easey-common/maps';
 import { SubmissionReportDTO } from '../dto/submission-report.dto';
 import { SubmissionListView } from 'src/entities/submission-list-vw.entity';
+import { format } from 'date-fns';
 
 @Injectable()
 export class SubmissionListMap extends BaseMap<
@@ -21,7 +22,9 @@ SubmissionReportDTO
         reportingFrequencyCode :  entity?.reportingFrequencyCode,
         submissionTypeCode :  entity?.submissionTypeCode,
         submissionId :  entity?.submissionId,
-        submissionDateTime :  entity?.submissionDateTime,
+        submissionDateTime : entity?.submissionDateTime
+        ? format(new Date(entity.submissionDateTime), 'yyyy-MM-dd HH:mm:ss')
+        : null,
         severityLevel :  entity?.severityLevel,
         mostRecent :  entity?.mostRecent,
         submissionStatus :  entity?.submissionStatus,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,7 +14,7 @@ import { QaTestExtensionExemptionModule } from './qa-test-extension-exemption/qa
 import { EmSubmissionAccessModule } from './em-submission-access/em-submission-access.module';
 import { SubmissionModule } from './submission/submission.module';
 import { MatsFileUploadModule } from './mats-file-upload/mats-file-upload.module';
-
+import { TestTypeCode } from './test-type-code/test-type-code.module';
 const routes = [
   {
     path: '/bookmarks',
@@ -47,6 +47,10 @@ const routes = [
   {
     path: '/mats-file-upload',
     module: MatsFileUploadModule,
+  },
+  {
+    path: '/',
+    module: TestTypeCode,
   },
   {
     path: '/admin',

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,7 +14,7 @@ import { QaTestExtensionExemptionModule } from './qa-test-extension-exemption/qa
 import { EmSubmissionAccessModule } from './em-submission-access/em-submission-access.module';
 import { SubmissionModule } from './submission/submission.module';
 import { MatsFileUploadModule } from './mats-file-upload/mats-file-upload.module';
-import { TestTypeCode } from './test-type-code/test-type-code.module';
+import { TestTypeCodeModule } from './test-type-code/test-type-code.module';
 import { HealthModule } from '@us-epa-camd/easey-common/health/health.module';
 
 const routes = [
@@ -56,7 +56,7 @@ const routes = [
   },
   {
     path: '/',
-    module: TestTypeCode,
+    module: TestTypeCodeModule,
   },
   {
     path: '/admin',

--- a/src/submission-report/submission-report-view.repository.ts
+++ b/src/submission-report/submission-report-view.repository.ts
@@ -42,11 +42,6 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
         'ss.mostRecent',
         'ss.submissionStatus',
         'ss.severityCode',
-        'ss.criticalErrLevelOne',
-        'ss.criticalErrLevelTwo',
-        'ss.nonCritical',
-        'ss.infoMessage',
-        'ss.adminOverride',
         'ss.submitter',
         'ss.monitorPlanId',
         'ss.reportingPeriodId'

--- a/src/submission-report/submission-report-view.repository.ts
+++ b/src/submission-report/submission-report-view.repository.ts
@@ -32,6 +32,7 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
         'ss.qaDataTypeCode',
         'ss.testTypeCode',
         'ss.locations',
+        'ss.reportingPeriod',
         'ss.identifyingInformation',
         'ss.reportingFrequencyCode',
         'ss.submissionTypeCode',
@@ -57,6 +58,12 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
         });
       }
   
+       if (quarter && year) {
+        query.andWhere('ss.reportingPeriod = :reportingPeriod', {
+            reportingPeriod: `${year} Q${quarter}`,
+        });
+      }
+      
       if (severityCode) {
         query.andWhere(
           `(ss.severityCode = :severityCode)`,

--- a/src/submission-report/submission-report-view.repository.ts
+++ b/src/submission-report/submission-report-view.repository.ts
@@ -32,7 +32,7 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
         'ss.qaDataTypeCode',
         'ss.testTypeCode',
         'ss.locations',
-        'ss.reportingPeriod',
+        'ss.identifyingInformation',
         'ss.reportingFrequencyCode',
         'ss.submissionTypeCode',
         'ss.submissionId',
@@ -54,12 +54,6 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
       if (orisCode) {
         query.andWhere('ss.orisCode = :orisCode', {
           orisCode
-        });
-      }
-  
-      if (quarter && year) {
-        query.andWhere('ss.reportingPeriod = :reportingPeriod', {
-            reportingPeriod: `${year} Q${quarter}`,
         });
       }
   

--- a/src/submission-report/submission-report-view.repository.ts
+++ b/src/submission-report/submission-report-view.repository.ts
@@ -20,12 +20,17 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
       severityCode,
       submissionType,
       submissionFrom,
-      submissionTo
+      submissionTo,
+      qaDataType,
+      testType,
+      locations
     } = params;
     let query = this.createQueryBuilder('ss').select([
         'ss.orisCode',
         'ss.facilityName',
         'ss.state',
+        'ss.qaDataTypeCode',
+        'ss.testTypeCode',
         'ss.locations',
         'ss.reportingPeriod',
         'ss.reportingFrequencyCode',
@@ -85,6 +90,27 @@ export class SubmissionListViewRepository extends Repository<SubmissionListView>
           { submissionTo },
         );
       }
+
+          if (qaDataType) {
+        query.andWhere(
+          `(ss.qaDataTypeCode = :qaDataType)`,
+          { qaDataType},
+        );
+      } 
+
+    if (testType) {
+        query.andWhere(
+          `(ss.testTypeCode = :testType)`,
+          { testType},
+        );
+      } 
+
+    if (locations) {
+      query.andWhere(
+        `string_to_array(replace(ss.locations, ' ', ''), ',') && :locations::text[]`,
+        { locations },
+      );
+    }
 
       return query.getMany();
     }

--- a/src/submission-report/submission-report.controller.ts
+++ b/src/submission-report/submission-report.controller.ts
@@ -8,6 +8,7 @@ import {
   ApiOperation,
   ApiSecurity,
   ApiTags,
+  ApiQuery
 } from '@nestjs/swagger';
 import { ApiExcludeControllerByEnv } from '../decorators/swagger-decorator';
 import { BadRequestResponse, NotFoundResponse } from '@us-epa-camd/easey-common/utilities/common-swagger';
@@ -37,6 +38,12 @@ export class SubmissionReportController {
   })
   @NotFoundResponse()
   @BadRequestResponse()
+  @ApiQuery({
+      style: 'pipeDelimited',
+      name: 'locations',
+      required: false,
+      explode: false,
+    })
   @ApiOperation({
     description: 'Retrieves Submission Report (CAT) per filter criteria.',
   })

--- a/src/test-type-code/test-type-code.controller.spec.ts
+++ b/src/test-type-code/test-type-code.controller.spec.ts
@@ -1,0 +1,51 @@
+import { ConfigService } from '@nestjs/config';
+import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { HttpModule } from '@nestjs/axios';
+import { DataSource, EntityManager } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TestTypeCodeService } from './test-type-code.service';
+import { TestTypeCode } from '../entities/test-type-code.entity';
+import { TestTypeCodeController } from './test-type-code.controller';
+
+describe('TestTypeCodeController', () => {
+  let controller: TestTypeCodeController;
+  let service: TestTypeCodeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LoggerModule, HttpModule],
+      controllers: [TestTypeCodeController],
+      providers: [
+        TestTypeCodeService,
+        ConfigService,
+        EntityManager,
+        {
+          provide: DataSource,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TestTypeCodeController>(
+        TestTypeCodeController,
+    );
+    service = module.get<TestTypeCodeService>(TestTypeCodeService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('Retrieves All Test Type Code', async () => {
+    const mockedValues = new TestTypeCode();
+    jest
+      .spyOn(service, 'findAll')
+      .mockResolvedValue([mockedValues]);
+
+    expect(await controller.findAll()).toEqual({
+      items: [mockedValues],
+    });
+  });
+
+});

--- a/src/test-type-code/test-type-code.controller.ts
+++ b/src/test-type-code/test-type-code.controller.ts
@@ -1,0 +1,22 @@
+import { TestTypeCodeService } from './test-type-code.service';
+import { TestTypeCode } from '../entities/test-type-code.entity';
+import {
+  Get
+} from '@nestjs/common/decorators';
+import { ArrayResponse } from '@us-epa-camd/easey-common/interfaces/common.interface';
+import { Controller } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+
+// Endpoint needs to be funtional but not part of swagger
+@ApiExcludeController()
+@Controller('test-type-code')
+export class TestTypeCodeController {
+  constructor(private readonly testTypeCodeService: TestTypeCodeService) {}
+
+  @Get()
+  async findAll(): Promise<ArrayResponse<TestTypeCode>> {
+    return {
+      items : await this.testTypeCodeService.findAll()
+    }; 
+  }
+}

--- a/src/test-type-code/test-type-code.module.ts
+++ b/src/test-type-code/test-type-code.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { TestTypeCodeController } from './test-type-code.controller';
+import { TestTypeCodeService } from './test-type-code.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [TestTypeCodeController],
+  providers: [TestTypeCodeService],
+})
+export class TestTypeCode {}

--- a/src/test-type-code/test-type-code.module.ts
+++ b/src/test-type-code/test-type-code.module.ts
@@ -8,4 +8,4 @@ import { TestTypeCodeService } from './test-type-code.service';
   controllers: [TestTypeCodeController],
   providers: [TestTypeCodeService],
 })
-export class TestTypeCode {}
+export class TestTypeCodeModule {}

--- a/src/test-type-code/test-type-code.service.ts
+++ b/src/test-type-code/test-type-code.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { TestTypeCode } from '../entities/test-type-code.entity';
+
+@Injectable()
+export class TestTypeCodeService {
+  constructor(
+    @InjectEntityManager()
+    private readonly entityManager: EntityManager,
+  ) {}
+
+  async findAll(): Promise<TestTypeCode[]> {
+    return await this.entityManager.find(TestTypeCode);
+  }
+}

--- a/src/test-type-code/test-type-conde.service.spec.ts
+++ b/src/test-type-code/test-type-conde.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from 'typeorm';
+import { TestTypeCodeService } from './test-type-code.service';
+
+describe('TestTypeCodeService', () => {
+  let service: TestTypeCodeService;
+  let mockEntityManager: Partial<EntityManager>;
+
+  beforeEach(async () => {
+     mockEntityManager = {
+      find: jest.fn() as jest.MockedFunction<typeof mockEntityManager.find>,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TestTypeCodeService,
+        {
+           provide: EntityManager,
+          useValue: mockEntityManager,
+        },
+      ],
+    }).compile();
+
+    service = module.get(TestTypeCodeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should successfully return data only from test type code', async () => {
+
+     const mockTestTypeCodes = [{ id: 'Rata', name: 'Test Rata' }, { id: 'Line', name: 'Test Line' }];
+    (mockEntityManager.find as jest.Mock).mockResolvedValue(mockTestTypeCodes);
+
+
+    let result = await service.findAll();
+
+    expect(result).toEqual(mockTestTypeCodes);
+   
+  });
+
+});

--- a/test/object-generators/submisison-report-list.ts
+++ b/test/object-generators/submisison-report-list.ts
@@ -21,11 +21,6 @@ export const genSubmissionList = <RepoType>(amount = 1): RepoType[] => {
       mostRecent :  faker.datatype.string(),
       submissionStatus :  faker.datatype.string(),
       severityCode :  faker.datatype.string(),
-      criticalErrLevelOne :  faker.datatype.string(),
-      criticalErrLevelTwo :  faker.datatype.string(),
-      nonCritical :  faker.datatype.string(),
-      infoMessage :  faker.datatype.string(),
-      adminOverride :  faker.datatype.string(),
       submitter :  faker.datatype.string()
     } as unknown as RepoType);
   }


### PR DESCRIPTION
ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6710
https://github.com/US-EPA-CAMD/easey-ui/issues/6706
https://github.com/US-EPA-CAMD/easey-ui/issues/6705

changes https://github.com/US-EPA-CAMD/easey-ui/issues/6710:
Time of submission is not being shown. It should be showing both the date and time.
Updated DTO to add date and time to client response. 

**The "Critical Error Level 1", "Critical Error Level 2", "Non-Critical", "Informational Message", "Administrative Override" columns After Teams discussion (5/29, Ann, Dwayne, Jonas, Mark), we have decided to not include these columns in the report.**

changes for https://github.com/US-EPA-CAMD/easey-ui/issues/6706:
MP Location is available as a filter, QA Data Type is available as a filter, and Test Type is available as a filter.

changes for https://github.com/US-EPA-CAMD/easey-ui/issues/6705:
The "Reporting Period" column is now labeled "Identifying Information" instead.
Remove dropdown for Reporting Period because the column is not base on only  yr/quarter anymore.