### PR TITLE
Feature/6863 export report multiple quarters

### DIFF
--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -625,7 +625,7 @@ export class SubmissionService {
       for (const period of item.emissionsReportingPeriods) {
         const checkPromise = this.entityManager.query(
           `SELECT window_expired_date, facility_name, oris_code, configuration
-           FROM camdecmpswks.vw_em_eval_and_submit 
+           FROM camdecmpswks.vw_em_eval_and_submit_earliest
            WHERE mon_plan_id = $1 
            `,
           [item.monPlanId],


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6863

## Main Changes:

- Updated the `camdecmpswks.vw_em_eval_and_submit` call to `camdecmpswks.vw_em_eval_and_submit_earliest`, which has the same behavior.