### PR TITLE
Filtering Mats Certification Statement

### DIFF
--- a/src/mats-file-upload/mats-file-upload.service.ts
+++ b/src/mats-file-upload/mats-file-upload.service.ts
@@ -173,7 +173,7 @@ export class MatsFileUploadService {
 
       const documents: any = [];
       // Add MATS Certification Statement
-      await this.documentService.addCertificationStatements(submission.monPlanId, documents);
+      await this.documentService.addCertificationStatements(submission.monPlanId, documents, true);
 
       // Writing Certification Statements...
       writeFileSync(`${folderPath}/${documents[0]?.documentTitle}.html`, documents[0]?.context);

--- a/src/submission/document.service.ts
+++ b/src/submission/document.service.ts
@@ -210,7 +210,7 @@ export class DocumentService {
     }
   }
 
-  public async addCertificationStatements(monPlanIdentifier: string, documents: any[]) {
+  public async addCertificationStatements(monPlanIdentifier: string, documents: any[], addMat?: boolean) {
     const response = await firstValueFrom(
       this.httpService.get(
         `${this.configService.get<string>(
@@ -224,7 +224,11 @@ export class DocumentService {
       ),
     );
 
-    const statements = response.data.items;
+    let statements
+    if(addMat)
+      statements = response.data.items.filter( i => i?.statementId === 3);
+    else
+      statements = response.data.items;
 
     documents.push({
       documentTitle: `Certification Statements`,


### PR DESCRIPTION
ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/6750#issuecomment-3225550472
changes: 
Updating logic in addCertificationStatements method to filter only mats statement when mats-file-upload/process is call. 
According to the acceptance criteria the mats has to be filter.  Non mats need to be remove. 