### PR TITLE
fix: generate recipient-specific attachments for submission feedback …

### DIFF
--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -43,7 +43,7 @@ export class MailService {
       
       // Always add email addresses to context for template replacement
       const context = { ...options.context };
-      context.toEmail = options.bodyToEmailsList || options.to;
+      context.toEmail = options.to;
       context.fromEmail = options.from;
       
       const html = await this.easeyContentTemplateService.renderHandlebarsTemplate(

--- a/src/mats-file-upload/mats-file-upload.service.ts
+++ b/src/mats-file-upload/mats-file-upload.service.ts
@@ -30,6 +30,7 @@ import { MailService } from '../mail/mail.service';
 import { DocumentService } from '../submission/document.service';
 import { ClientConfigService } from '../mail/client-config.service';
 import { EMAIL_TEMPLATE_IDS } from '../constants/email-template-ids';
+import { combineEmailAddresses } from '../utilities/email-helper'
 
 
 
@@ -300,15 +301,14 @@ export class MatsFileUploadService {
     //Get the recipients list from the recipient's list API
     const recipientsListApiEnabled = this.configService.get<boolean>('app.recipientsListApiEnabled');
 
-    submissionEmailParamsDto.toEmail = submission.userEmail;
-    submissionEmailParamsDto.ccEmail = recipientsListApiEnabled ? await this.recipientListService.getEmailRecipients(
+    const recipientsList = recipientsListApiEnabled ? await this.recipientListService.getEmailRecipients(
       submission.userId,
       'PDF',
       true,
       'SUBMISSIONCONFIRMATION',
       submission.facId?.toString(),
     ) : '';
-
+    const allToEmails = combineEmailAddresses(submission.userEmail, recipientsList);
     let supportEmail: string;
     try {
       const ecmpsClientConfig = await this.clientConfigService.getECMPSClientConfig();
@@ -328,15 +328,22 @@ export class MatsFileUploadService {
     submissionEmailParamsDto.templateContext['LOCATION_LIST'] = primaryLocation;
     submissionEmailParamsDto.templateContext['SUBMISSION_DATE'] = currentDate; //submission.completedTime will after email send
     submissionEmailParamsDto.templateContext['supportEmail'] = supportEmail;
+    submissionEmailParamsDto.templateContext['allToEmails'] = allToEmails.join(', ');
 
-    this.mailService.sendTemplateEmail({
-      templateId: EMAIL_TEMPLATE_IDS.MATS_SUBMISSION,
-      to: submissionEmailParamsDto.toEmail,
-      cc: submissionEmailParamsDto.ccEmail,
-      from: this.configService.get<string>('app.defaultFromEmail'),
-      subject,
-      context: submissionEmailParamsDto.templateContext,
-    });
+    for (const toEmail of allToEmails) {
+
+      try {
+        this.mailService.sendTemplateEmail({
+          templateId: EMAIL_TEMPLATE_IDS.MATS_SUBMISSION,
+          to: toEmail,
+          from: this.configService.get<string>('app.defaultFromEmail'),
+          subject,
+          context: submissionEmailParamsDto.templateContext,
+        });
+      } catch (e) {
+        this.logger.error('Error attempting to send MATS Data Submission Feedback');
+      }
+    }
   }
 
   async getMatsSubmissionWithLocation(monLocId: string) {

--- a/src/submission/submission-email.service.ts
+++ b/src/submission/submission-email.service.ts
@@ -8,6 +8,7 @@ import { DataSetService } from '../dataset/dataset.service';
 import { SeverityCode } from '../entities/severity-code.entity';
 import { ReportingPeriod } from '../entities/reporting-period.entity';
 import {
+  isCritical1Severity,
   HighestSeverityRecord,
   SubmissionEmailParamsDto, SubmissionFeedbackEmailData,
 } from '../dto/submission-email-params.dto';
@@ -182,9 +183,13 @@ export class SubmissionEmailService {
       submissionEmailParamsDto.facId?.toString(),
     ) : '';
 
-    const toEmails = this.combineEmailAddresses(submissionEmailParamsDto.toEmail, recipientsList);
-    submissionEmailParamsDto.templateContext['toEmail'] = toEmails;
-    submissionEmailParamsDto.toEmail = toEmails;
+    const allToEmails = this.combineEmailAddresses(submissionEmailParamsDto.toEmail, recipientsList);
+    const spacedEmails = allToEmails.replace(/([,;])/g, '$1 ')
+    //For submission-confirmation
+    submissionEmailParamsDto.templateContext['allToEmails'] = spacedEmails;
+    //For submission-feedback - update this per recipient later
+    submissionEmailParamsDto.templateContext['toEmail'] = submissionEmailParamsDto.toEmail;
+    submissionEmailParamsDto.toEmail = spacedEmails;
     submissionEmailParamsDto.templateContext['fromEmail'] = submissionEmailParamsDto.fromEmail;
     const emailSubject = await this.constructEmailSubject(submissionEmailParamsDto);
     this.logger.debug(`Constructed email subject: ${emailSubject}`,);
@@ -224,18 +229,6 @@ export class SubmissionEmailService {
       submissionEmailParamsDto.templateContext['evaluationReportsContent'] = evaluationReportsContent;
     }
 
-    const templateRecord = await this.easeyContentTemplateService.getTemplateById(EMAIL_TEMPLATE_IDS.SUBMISSION_FEEDBACK);
-    const attachmentContent = await this.easeyContentTemplateService.renderHandlebarsTemplate(
-      templateRecord.templateLocation,
-      submissionEmailParamsDto.templateContext,
-    );
-
-    const feedbackAttachmentDocuments = [];
-    feedbackAttachmentDocuments.push({
-      filename: `${submissionSet.orisCode}_SUBMISSION_FEEDBACK.html`,
-      content: attachmentContent,
-    });
-
     //Finally, return the collected email data
     this.logger.log(`Completed processing building data for : ${submissionEmailParamsDto.processCode}`);
     return new SubmissionFeedbackEmailData(
@@ -244,12 +237,34 @@ export class SubmissionEmailService {
       emailSubject,
       EMAIL_TEMPLATE_IDS.SUBMISSION_CONFIRMATION,
       submissionEmailParamsDto.templateContext,
-      feedbackAttachmentDocuments,
+      [],// Empty attachments array - generate per recipient
       submissionEmailParamsDto.submissionSet,
       submissionEmailParamsDto.submissionQueueRecords,
       submissionEmailParamsDto.processCode,
     );
   }
+
+  public async generateRecipientSpecificAttachment(
+  submissionFeedbackEmailData: SubmissionFeedbackEmailData,
+  recipientEmail: string
+): Promise<any> {
+  // Create a copy of the template context to avoid modifying the original
+  const recipientSpecificContext = { ...submissionFeedbackEmailData.templateContext };
+  
+  // Update the toEmail in the context to show only this specific recipient
+  recipientSpecificContext['toEmail'] = recipientEmail;
+
+  const templateRecord = await this.easeyContentTemplateService.getTemplateById(EMAIL_TEMPLATE_IDS.SUBMISSION_FEEDBACK);
+  const attachmentContent = await this.easeyContentTemplateService.renderHandlebarsTemplate(
+    templateRecord.templateLocation,
+    recipientSpecificContext,
+  );
+
+  return {
+    filename: `${submissionFeedbackEmailData.submissionSet.orisCode}_SUBMISSION_FEEDBACK.html`,
+    content: attachmentContent,
+  };
+}
 
   private combineEmailAddresses(primaryEmail: string, additionalEmails: string): string {
     if (!additionalEmails || additionalEmails.trim() === '') {
@@ -261,7 +276,7 @@ export class SubmissionEmailService {
     }
   
   // Combine with proper comma separator
-    return `${primaryEmail},${additionalEmails}`;
+    return `${primaryEmail}, ${additionalEmails}`;
   }
 
   private async setCommonParams(
@@ -347,6 +362,7 @@ export class SubmissionEmailService {
     const severityLevelCode = submissionEmailParamsDto?.highestSeverityRecord?.severityCode?.severityCode;
 
     submissionEmailParamsDto.templateContext['severityLevelCode'] = severityLevelCode;
+    submissionEmailParamsDto.templateContext['isCritical1Error'] = isCritical1Severity(submissionEmailParamsDto?.highestSeverityRecord);
     submissionEmailParamsDto.templateContext['hasNonNoneSeverity'] = severityLevelCode !== 'NONE';
 
     const ecmpsClientConfig = await this.clientConfigService.getECMPSClientConfig();
@@ -409,20 +425,27 @@ export class SubmissionEmailService {
     const monLocationIds = submissionEmailParamsDto.monLocationIds
       .split(',')
       .map((item) => item.trim());
+    const unitStackPipes = submissionEmailParamsDto.unitStackPipe
+      .split(',')
+      .map((item) => item.trim());
     const promises = [];
 
+    let index = 0;
     for (const monLocationId of monLocationIds) {
-      reportParams.locationId = monLocationId;
+      let unitStackPipe = unitStackPipes[index];
+      const locationId = monLocationId;
+      const params = {...reportParams, locationId}
       const promise = this.dataSetService
-        .getDataSet(reportParams, true)
+        .getDataSet(params, true)
         .then((report) => {
           return this.submissionFeedbackRecordService.generateSummaryTableForUnitStack(
             report,
-            reportParams.locationId,
+            unitStackPipe,
           );
         });
 
       promises.push(promise);
+      index++;
     }
 
     const results = await Promise.all(promises);

--- a/src/submission/submission-email.service.ts
+++ b/src/submission/submission-email.service.ts
@@ -8,7 +8,6 @@ import { DataSetService } from '../dataset/dataset.service';
 import { SeverityCode } from '../entities/severity-code.entity';
 import { ReportingPeriod } from '../entities/reporting-period.entity';
 import {
-  isCritical1Severity,
   HighestSeverityRecord,
   SubmissionEmailParamsDto, SubmissionFeedbackEmailData,
 } from '../dto/submission-email-params.dto';
@@ -362,7 +361,6 @@ export class SubmissionEmailService {
     const severityLevelCode = submissionEmailParamsDto?.highestSeverityRecord?.severityCode?.severityCode;
 
     submissionEmailParamsDto.templateContext['severityLevelCode'] = severityLevelCode;
-    submissionEmailParamsDto.templateContext['isCritical1Error'] = isCritical1Severity(submissionEmailParamsDto?.highestSeverityRecord);
     submissionEmailParamsDto.templateContext['hasNonNoneSeverity'] = severityLevelCode !== 'NONE';
 
     const ecmpsClientConfig = await this.clientConfigService.getECMPSClientConfig();
@@ -425,27 +423,20 @@ export class SubmissionEmailService {
     const monLocationIds = submissionEmailParamsDto.monLocationIds
       .split(',')
       .map((item) => item.trim());
-    const unitStackPipes = submissionEmailParamsDto.unitStackPipe
-      .split(',')
-      .map((item) => item.trim());
     const promises = [];
 
-    let index = 0;
     for (const monLocationId of monLocationIds) {
-      let unitStackPipe = unitStackPipes[index];
-      const locationId = monLocationId;
-      const params = {...reportParams, locationId}
+      reportParams.locationId = monLocationId;
       const promise = this.dataSetService
-        .getDataSet(params, true)
+        .getDataSet(reportParams, true)
         .then((report) => {
           return this.submissionFeedbackRecordService.generateSummaryTableForUnitStack(
             report,
-            unitStackPipe,
+            reportParams.locationId,
           );
         });
 
       promises.push(promise);
-      index++;
     }
 
     const results = await Promise.all(promises);

--- a/src/submission/submission-process.service.ts
+++ b/src/submission/submission-process.service.ts
@@ -125,19 +125,24 @@ export class SubmissionProcessService {
 
         // Attempt to send an email. If sending an email for this particular file type fails,
         // log the error and continue attempting to send emails for the others
-        const emailList = submissionFeedbackEmailData.toEmail
-          ? submissionFeedbackEmailData.toEmail.split(/[;,]/).map(email => email.trim()).filter(Boolean)
-          : [];
+          const emailList = submissionFeedbackEmailData.toEmail
+        ? submissionFeedbackEmailData.toEmail.split(/[;,]+/).map(email => email.trim()).filter(Boolean)
+        : [];
+
         for (const toEmail of emailList) {
           try {
+            const recipientSpecificAttachment = await this.submissionEmailService.generateRecipientSpecificAttachment(
+            submissionFeedbackEmailData,
+            toEmail
+            );
+
             this.mailService.sendTemplateEmail({
               templateId: submissionFeedbackEmailData.emailTemplateId,
               to: toEmail,
               from: submissionFeedbackEmailData.fromEmail,
               subject: submissionFeedbackEmailData.subject,
               context: submissionFeedbackEmailData.templateContext,
-              attachments: submissionFeedbackEmailData.feedbackAttachmentDocuments,
-              bodyToEmailsList: emailList
+              attachments: [recipientSpecificAttachment],
             });
           } catch (e) {
             this.logger.error('Error attempting to send feedback email : ' + { processCode: submissionFeedbackEmailData.processCode }, e.stack, 'SubmissionProcessService');

--- a/src/utilities/email-helper.ts
+++ b/src/utilities/email-helper.ts
@@ -1,0 +1,23 @@
+export const combineEmailAddresses = (primaryEmail: string, additionalEmails: string): string[] => {
+    const emails: string[] = [];
+
+    // Add primary email if valid
+    if (primaryEmail && primaryEmail.trim() !== '') {
+        emails.push(primaryEmail.trim());
+    }
+
+    if (additionalEmails && additionalEmails.trim() !== '') {
+        // Split on comma or semicolon
+        const splitEmails = additionalEmails
+            .split(/[,;]+/)
+            .map(e => e.trim())
+            .filter(e => e !== '');
+
+        emails.push(...splitEmails);
+    }
+
+    // Remove duplicates (case-insensitive)
+    const uniqueEmails = [...new Set(emails.map(e => e.toLowerCase()))];
+
+    return uniqueEmails;
+}


### PR DESCRIPTION
## Ticket
[Improve Email Sending Architecture, Async Processing and Email Per Recipient](https://github.com/US-EPA-CAMD/easey-ui/issues/6885)

## Changes
- Move attachment generation from data collection phase to email sending phase
- Add generateRecipientSpecificAttachment method to create unique attachments per recipient
- Update email sending loop to include recipient-specific email addresses in attachments