### PR TITLE
Fix/6971 typeorm floats

### DIFF
--- a/src/entities/check-catalog-result.entity.ts
+++ b/src/entities/check-catalog-result.entity.ts
@@ -16,12 +16,14 @@ export class CheckCatalogResult extends BaseEntity {
   @PrimaryColumn({
     name: 'check_catalog_result_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   checkCatalogResultId: number;
 
   @Column({
     name: 'check_catalog_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   checkCatalogId: number;
 
@@ -34,12 +36,14 @@ export class CheckCatalogResult extends BaseEntity {
   @Column({
     name: 'response_catalog_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   responseCatalogId: number;
 
   @Column({
     name: 'es_allowed_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   esAllowedInd: number;
 

--- a/src/entities/check-catalog.entity.ts
+++ b/src/entities/check-catalog.entity.ts
@@ -7,13 +7,18 @@ export class CheckCatalog extends BaseEntity {
   @PrimaryColumn({
     name: 'check_catalog_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   checkCatalogId: number;
 
   @Column({ name: 'check_type_cd' })
   checkTypeCode: string;
 
-  @Column({ name: 'check_number', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'check_number',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   checkNumber: number;
 
   @Column({ name: 'check_name' })

--- a/src/entities/em-submission-access-vw.entity.ts
+++ b/src/entities/em-submission-access-vw.entity.ts
@@ -6,6 +6,7 @@ export class EmSubmissionAccessView extends BaseEntity {
   @Column({
     name: 'em_sub_access_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 
@@ -17,6 +18,7 @@ export class EmSubmissionAccessView extends BaseEntity {
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportingPeriodId: number;
 
@@ -84,12 +86,14 @@ export class EmSubmissionAccessView extends BaseEntity {
   @Column({
     name: 'fac_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   facilityId: number;
 
   @Column({
     name: 'oris_code',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   orisCode: number;
 
@@ -104,10 +108,15 @@ export class EmSubmissionAccessView extends BaseEntity {
   @Column({
     name: 'calendar_year',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   year: number;
 
-  @Column({ name: 'quarter', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'quarter',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   quarter: number;
 
   @Column({ name: 'report_freq_cd' })
@@ -119,6 +128,7 @@ export class EmSubmissionAccessView extends BaseEntity {
   @Column({
     name: 'submission_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   lastSubmissionId: number;
 

--- a/src/entities/em-submission-access.entity.ts
+++ b/src/entities/em-submission-access.entity.ts
@@ -21,6 +21,7 @@ export class EmSubmissionAccess extends BaseEntity {
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportingPeriodId: number;
 

--- a/src/entities/es-spec.entity.ts
+++ b/src/entities/es-spec.entity.ts
@@ -20,13 +20,18 @@ export class EsSpec extends BaseEntity {
   @Column({
     name: 'check_catalog_result_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   checkCatalogResultId: number;
 
   @Column({ name: 'severity_cd' })
   severityCode: string;
 
-  @Column({ name: 'fac_id', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'fac_id',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   facilityId: number;
 
   @Column({ name: 'location_name_list' })
@@ -44,6 +49,7 @@ export class EsSpec extends BaseEntity {
   @Column({
     name: 'match_historical_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   matchHistoricalIndicator: number;
 
@@ -62,7 +68,11 @@ export class EsSpec extends BaseEntity {
   @Column({ name: 'note' })
   note: string;
 
-  @Column({ name: 'active_ind', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'active_ind',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   active: number;
 
   @Column({ name: 'userid' })

--- a/src/entities/mats-data-submission.entity.ts
+++ b/src/entities/mats-data-submission.entity.ts
@@ -33,7 +33,11 @@ export class MatsDataSubmission extends BaseEntity {
   @Column({ name: 'original_sub_id', nullable: true })
   originalSubId: number;
 
-  @Column({ name: 'fac_id', type: 'numeric', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'fac_id',
+    type: 'numeric',
+    transformer: new NumericColumnTransformer(),
+  })
   facId: number;
 
   @Column({ name: 'mon_plan_id' })
@@ -69,3 +73,4 @@ export class MatsDataSubmission extends BaseEntity {
   @Column({ name: 'activity_id', nullable: true })
   activityId: string;
 }
+

--- a/src/entities/stack-pipe.entity.ts
+++ b/src/entities/stack-pipe.entity.ts
@@ -40,6 +40,7 @@ export class StackPipe extends BaseEntity {
   @Column({
     name: 'fac_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   facId: number;
 

--- a/src/entities/submission-list-vw.entity.ts
+++ b/src/entities/submission-list-vw.entity.ts
@@ -7,6 +7,7 @@ export class SubmissionListView extends BaseEntity {
   @Column({
     name: 'oris_code',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   orisCode: number;
 
@@ -58,6 +59,7 @@ export class SubmissionListView extends BaseEntity {
   @Column({
     name: 'submission_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   submissionId: number;
 
@@ -95,12 +97,14 @@ export class SubmissionListView extends BaseEntity {
   @Column({
     name: 'mon_plan_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   monitorPlanId: number;
 
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportingPeriodId: number;
 }

--- a/src/entities/unit.entity.ts
+++ b/src/entities/unit.entity.ts
@@ -18,6 +18,7 @@ export class Unit extends BaseEntity {
   @PrimaryColumn({
     name: 'unit_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6971

## Main Changes:

- In the `@Column` annotation for numeric types (integer and float), explicitly set the type to `numeric` to prevent TypeORM from coercing the value to an integer.