### PR TITLE
Force nodemailer to 7.0.11 and mailparser to 3.9.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "class-validator": "0.14.3",
     "mailparser": "3.9.1",
     "nodemailer": "7.0.11",
-    "preview-email/nodemailer": "7.0.0"
+    "preview-email/nodemailer": "7.0.11"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.955.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "xml2js": "^0.5.0",
     "wrap-ansi": "^7.0.0",
     "class-validator": "0.14.3",
-    "preview-email/nodemailer": "^7.0.0"
+    "mailparser": "3.9.1",
+    "nodemailer": "7.0.11",
+    "preview-email/nodemailer": "7.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.955.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,6 +3619,15 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zone-eu/mailsplit@5.4.8":
+  version "5.4.8"
+  resolved "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz#fc3e433f5b8132103324d7728f3fa00426aea822"
+  integrity sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==
+  dependencies:
+    libbase64 "1.3.0"
+    libmime "5.3.7"
+    libqp "2.1.1"
+
 accepts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
@@ -6448,30 +6457,21 @@ magic-string@0.30.17:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
 
-mailparser@^3.7.1:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/mailparser/-/mailparser-3.7.5.tgz#f1a3f04c58be8bf2a20e26506b56fbbabf416345"
-  integrity sha512-o59RgZC+4SyCOn4xRH1mtRiZ1PbEmi6si6Ufnd3tbX/V9zmZN1qcqu8xbXY62H6CwIclOT3ppm5u/wV2nujn4g==
+mailparser@3.9.1, mailparser@^3.7.1:
+  version "3.9.1"
+  resolved "https://registry.npmjs.org/mailparser/-/mailparser-3.9.1.tgz#6adbf451693ce22b660a83c73c8a15939ecf9c19"
+  integrity sha512-6vHZcco3fWsDMkf4Vz9iAfxvwrKNGbHx0dV1RKVphQ/zaNY34Buc7D37LSa09jeSeybWzYcTPjhiZFxzVRJedA==
   dependencies:
+    "@zone-eu/mailsplit" "5.4.8"
     encoding-japanese "2.2.0"
     he "1.2.0"
     html-to-text "9.0.5"
     iconv-lite "0.7.0"
     libmime "5.3.7"
     linkify-it "5.0.0"
-    mailsplit "5.4.6"
-    nodemailer "7.0.9"
+    nodemailer "7.0.11"
     punycode.js "2.3.1"
-    tlds "1.260.0"
-
-mailsplit@5.4.6:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/mailsplit/-/mailsplit-5.4.6.tgz#0e0c934c6369fdcc77c5128ea60bb35950d200c9"
-  integrity sha512-M+cqmzaPG/mEiCDmqQUz8L177JZLZmXAUpq38owtpq2xlXlTSw+kntnxRt2xsxVFFV6+T8Mj/U0l5s7s6e0rNw==
-  dependencies:
-    libbase64 "1.3.0"
-    libmime "5.3.7"
-    libqp "2.1.1"
+    tlds "1.261.0"
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -6684,12 +6684,12 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
-nodemailer@7.0.9:
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-7.0.9.tgz#fe5abd4173e08e01aa243c7cddd612ad8c6ccc18"
-  integrity sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==
+nodemailer@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.0.tgz#3dda775f202d279e1abaa9422428ff3ff35a8830"
+  integrity sha512-9QyEp969UmUWVDB2gVQvxHm1bqkyuC5YZIyX/ySJUpIVyXpuEFyBAuoFFs+G5/C2ZaUp9F5A65DPfxedfVHXXQ==
 
-nodemailer@^6.9.13, nodemailer@^7.0.0, nodemailer@^7.0.11:
+nodemailer@7.0.11, nodemailer@^6.9.13, nodemailer@^7.0.11:
   version "7.0.11"
   resolved "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz#5f7b06afaec20073cff36bea92d1c7395cc3e512"
   integrity sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==
@@ -7935,10 +7935,10 @@ tinyglobby@^0.2.15:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
-tlds@1.260.0:
-  version "1.260.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.260.0.tgz#666c2584cf627b4296e888b799ec341be42821ac"
-  integrity sha512-78+28EWBhCEE7qlyaHA9OR3IPvbCLiDh3Ckla593TksfFc9vfTsgvH7eS+dr3o9qr31gwGbogcI16yN91PoRjQ==
+tlds@1.261.0:
+  version "1.261.0"
+  resolved "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz#055e412e92f01f84a9c8ac0504d3472d68b3c4c9"
+  integrity sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==
 
 tldts-core@^6.1.86:
   version "6.1.86"


### PR DESCRIPTION
Force nodemailer to 7.0.11 and mailparser to 3.9.1 via Yarn resolutions. Resolves Dependabot alerts #111 and #112.