### PR TITLE
Removed emailRecipientList endpoint from camd-services api swagger docs

### DIFF
--- a/src/mail/mail.controller.ts
+++ b/src/mail/mail.controller.ts
@@ -101,6 +101,7 @@ export class MailController {
   }
 
   @Post('email/emailRecipientList')
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Email recipient list retrieved successfully',
     type: EmailRecipientListResponseDto,


### PR DESCRIPTION
## Ticket
[Remove emailRecipientList endpoint from camd-services api swagger docs](http://github.com/US-EPA-CAMD/easey-ui/issues/7156)

## Change
Add `ApiExcludeEndpointByEnv` decorator in email/emailRecipientList post endpoint 
