### PR TITLE
Feature/7290 CAPAS POST switch

### DIFF
--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -9,6 +9,7 @@ ecmpsHost: https://ecmps-beta.app.cloud.gov/ecmps
 cdxUrl: https://test.epacdx.net/
 epaAnalystLink: https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
 recipientsListApi: https://cbsprodbeta.epa.gov/CBS/api/auth-mgmt/emailRecipients
+recipientsListApiMethod: GET
 recipientsListApiEnabled: true
 maxConnectionPool: 30
 idleTimeout: 30000

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -8,6 +8,7 @@ importMatsS3Bucket: cg-313e2894-003b-4eda-88ca-ce57b954a57d
 ecmpsHost: https://ecmps-perf.app.cloud.gov/ecmps
 epaAnalystLink: https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
 recipientsListApi: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/emailRecipients
+recipientsListApiMethod: GET
 recipientsListApiEnabled: false
 maxConnectionPool: 30
 idleTimeout: 30000

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -9,6 +9,7 @@ ecmpsHost: https://easey.epa.gov/ecmps
 cdxUrl: https://cdx.epa.gov/
 epaAnalystLink: https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
 recipientsListApi: https://camd.epa.gov/CBS/api/auth-mgmt/emailRecipients
+recipientsListApiMethod: GET
 recipientsListApiEnabled: true
 maxConnectionPool: 30
 idleTimeout: 30000

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -9,6 +9,7 @@ ecmpsHost: https://ecmps-stg.app.cloud.gov/ecmps
 cdxUrl: https://test.epacdx.net/
 epaAnalystLink: https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
 recipientsListApi: https://cbsstagei.epa.gov/CBS/api/auth-mgmt/emailRecipients
+recipientsListApiMethod: GET
 recipientsListApiEnabled: true
 maxConnectionPool: 30
 idleTimeout: 5000

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -9,6 +9,7 @@ ecmpsHost: https://ecmps-tst.app.cloud.gov/ecmps
 cdxUrl: https://test.epacdx.net/
 epaAnalystLink: https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
 recipientsListApi: https://cbsstagei.epa.gov/CBS/api/auth-mgmt/emailRecipients
+recipientsListApiMethod: GET
 recipientsListApiEnabled: true
 maxConnectionPool: 30
 idleTimeout: 5000

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -20,6 +20,7 @@ ecmpsHost: https://ecmps-dev.app.cloud.gov/ecmps
 cdxUrl: https://dev.epacdx.net/
 epaAnalystLink: https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
 recipientsListApi: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/emailRecipients
+recipientsListApiMethod: GET
 recipientsListApiEnabled: true
 maxConnectionPool: 30
 idleTimeout: 30000

--- a/manifest.yml
+++ b/manifest.yml
@@ -46,6 +46,7 @@ applications:
       TZ: America/New_York
       EASEY_CAMD_SERVICES_RECIPIENT_LIST_API: ((recipientsListApi))
       EASEY_CAMD_SERVICES_RECIPIENT_LIST_API_ENABLED: ((recipientsListApiEnabled))
+      EASEY_CAMD_SERVICES_RECIPIENT_LIST_API_METHOD: ((recipientsListApiMethod))
       EASEY_DB_MAX_CONNECTION_POOL: ((maxConnectionPool))
       EASEY_DB_IDLE_TIMEOUT: ((idleTimeout))
       EASEY_DB_CONNECTION_TIMEOUT: ((connectionTimeout))

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -136,6 +136,8 @@ export default registerAs('app', () => ({
   ),
   recipientsListApi: getConfigValue('EASEY_CAMD_SERVICES_RECIPIENT_LIST_API', 'https://cbsstagei.epa.gov/CBSD'),
   recipientsListApiEnabled: getConfigValueBoolean('EASEY_CAMD_SERVICES_RECIPIENT_LIST_API_ENABLED',true),
+  // HTTP verb for the recipients-list endpoint: 'GET' or 'POST'. Defaults to GET.
+  recipientsListApiMethod: getConfigValue('EASEY_CAMD_SERVICES_RECIPIENT_LIST_API_METHOD', 'GET'),
   enableLocalEmailPreview: getConfigValueBoolean('EASEY_CAMD_SERVICES_ENABLE_LOCAL_EMAIL_PREVIEW',false),
   localEmailPreviewDirectory: getConfigValue('EASEY_CAMD_SERVICES_LOCAL_EMAIL_PREVIEW_DIRECTORY'),
   localEmailPreviewOpen: getConfigValueBoolean('EASEY_CAMD_SERVICES_LOCAL_EMAIL_PREVIEW_OPEN', true),

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -136,7 +136,6 @@ export default registerAs('app', () => ({
   ),
   recipientsListApi: getConfigValue('EASEY_CAMD_SERVICES_RECIPIENT_LIST_API', 'https://cbsstagei.epa.gov/CBSD'),
   recipientsListApiEnabled: getConfigValueBoolean('EASEY_CAMD_SERVICES_RECIPIENT_LIST_API_ENABLED',true),
-  // HTTP verb for the recipients-list endpoint: 'GET' or 'POST'. Defaults to GET.
   recipientsListApiMethod: getConfigValue('EASEY_CAMD_SERVICES_RECIPIENT_LIST_API_METHOD', 'GET'),
   enableLocalEmailPreview: getConfigValueBoolean('EASEY_CAMD_SERVICES_ENABLE_LOCAL_EMAIL_PREVIEW',false),
   localEmailPreviewDirectory: getConfigValue('EASEY_CAMD_SERVICES_LOCAL_EMAIL_PREVIEW_DIRECTORY'),

--- a/src/submission/recipient-list.service.ts
+++ b/src/submission/recipient-list.service.ts
@@ -132,11 +132,12 @@ export class RecipientListService {
       }),
     };
 
-    // This request is a bit unconventional.  The CBS API expects a GET request with a body.
-    // Axios does not support this, so we are using the httpService.request method
+    // httpService.request is used so the body can be sent regardless of verb
+    // (axios can't send a body with GET). Non-POST falls back to GET.
+    const method = this.configService.get<string>('app.recipientsListApiMethod');
     const response: AxiosResponse<any> = await firstValueFrom(
       this.httpService.request({
-        method: 'GET',
+        method: method === 'POST' ? 'POST' : 'GET',
         url: recipientsListApiUrl,
         headers: headers,
         data: body,

--- a/src/submission/recipient-list.service.ts
+++ b/src/submission/recipient-list.service.ts
@@ -132,8 +132,8 @@ export class RecipientListService {
       }),
     };
 
-    // httpService.request is used so the body can be sent regardless of verb
-    // (axios can't send a body with GET). Non-POST falls back to GET.
+    // httpService.request is used so the body can be sent regardless of verb (axios can't send a body with GET).
+    // The CBS API expects a GET request with a body, CAPAS expects POST.
     const method = this.configService.get<string>('app.recipientsListApiMethod');
     const response: AxiosResponse<any> = await firstValueFrom(
       this.httpService.request({


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7290

## Main Changes:

- Add an environment variable to drive the HTTP verb used for the requests in the `RecipientListService`. This will need to be set to POST when the target is changed from the CBS service to the CAPAS service. The requests already pass parameters via the body, so only the request method is toggled.